### PR TITLE
Add sender to log ticket for tcp / ip log client.

### DIFF
--- a/src/log_client.py
+++ b/src/log_client.py
@@ -458,7 +458,7 @@ class TCPLoggerClient(LoggerClient):
 
 	msg = '%.6d %.8s %s %s  %s' % (pid, self.uname,
 				       e_errors.sevdict[severity],name,msg)
-	ticket = {'work':'log_message', 'message':msg}
+	ticket = {'work':'log_message', 'sender': self.hostname, 'message':msg}
         Trace.trace(301, "TCP %s"%(ticket,))
         try:
             self.message_buffer.put_nowait(ticket)


### PR DESCRIPTION
Otherwise log server may identify sender from the last udp message which is not always ftrom the same client.

https://www-enstore.fnal.gov/Bugzilla/show_bug.cgi?id=2483