### PR TITLE
Fixes "mover stuck in SETUP".

### DIFF
--- a/src/mover.py
+++ b/src/mover.py
@@ -991,7 +991,7 @@ class Mover(dispatching_worker.DispatchingWorker,
         if attr != 'state':
             self.__dict__[attr] = val
             return
-        Trace.trace(10, "setattr: %s to %s"%(attr, val))
+        Trace.trace(10, "setattr: %s to %s" % (attr, val))
         try:
             cur_val = getattr(self, 'state', None)
             if val != cur_val:
@@ -1019,7 +1019,7 @@ class Mover(dispatching_worker.DispatchingWorker,
             del(tb)
             pass #don't want any errors here to stop us
         self.__dict__[attr] = val
-        Trace.trace(10, "set state old: %s new: %s %s"%(cur_val, state_name(val), self.__dict__['state_change_time'] ))
+        Trace.trace(10, "set state old: %s new: %s %s" % (cur_val, state_name(val), self.__dict__['state_change_time'] ))
 
 
     def dump(self, ticket):
@@ -5060,7 +5060,7 @@ class Mover(dispatching_worker.DispatchingWorker,
                                                                  server_address=vc['address'], logc = self.logclient)
         except Exception, detail:
             exc, msg, tb = sys.exc_info()
-            Trace.log(e_errors.ERROR, "finish_transfer_setup failed:  %s %s %s %s"%
+            Trace.log(e_errors.ERROR, "finish_transfer_setup failed:  %s %s %s %s" %
                       (exc, msg, detail, traceback.format_tb(tb)))
             self.transfer_failed(e_errors.NET_ERROR, msg, error_source=NETWORK)
             self.state = self.save_state
@@ -6183,7 +6183,7 @@ n the drive"%(self.current_volume,))
                 Trace.trace(10, 'connect_client: listening')
                 self.listen_socket.listen(1)
                 Trace.trace(10, 'connect_client: listening  done')
-                
+
                 # need a control connection setup
                 # otherwise: not because it must be left open
                 ticket['mover']['callback_addr'] = (host,port) #client expects this
@@ -6277,7 +6277,7 @@ n the drive"%(self.current_volume,))
                         return
 
                 #Check if the socket is open for reading and/or writing.
-                Trace.trace(10, 'connect_client: waiting on %s for %s'%(self.control_socket, self.connect_to*self.connect_retry))
+                Trace.trace(10, 'connect_client: waiting on %s for %s' % (self.control_socket, self.connect_to*self.connect_retry))
 
                 r, w, ex = select.select([self.control_socket], [self.control_socket], [], self.connect_to*self.connect_retry)
 

--- a/src/udp_common.py
+++ b/src/udp_common.py
@@ -62,7 +62,7 @@ def __get_callback(host, port):
                 error_message = "%s\n%s" % (error_message,
                                             "Check /etc/hosts and ifconfig -a"
                                             " for inconsistent information.")
-        elif msg.args[0] == errno.EADDRINUSE or msg.args[0] == errno.EINVAL:
+        elif msg.args[0] in (errno.EADDRINUSE, errno.EINVAL):
             # We should include the address information since we know it
             # is currently in use by another process.
 	    # Sometimes socket.gethostname() returns IPV6 address for IPV4 host name, causing errno.EINVAL
@@ -71,7 +71,6 @@ def __get_callback(host, port):
         else:
             error_message = msg.args[1]
 
-        #sys.stdout.write("%s\n" % error_message)
         sys.stdout.write("MY %s %s %s %s %s \n" % (error_message, host, port, hostinfo, address_family))
         # reraise exception
         raise socket.error, error_message


### PR DESCRIPTION
For unknown reason sock.socket.bind((host, port)) in udp_common.__get_callback(host, port)
sometimes fails with errno.EINVAL:
04:35:34 gmv18024.fnal.gov 056043 root E L8G2_007MV  finish_transfer_setup
failed:  <class 'socket.error'>
Invalid argument: ('fe80::ae1f:6bff:fe41:7884%eth0', 0)
['  File "/opt/enstore/sbin/mover", line 5065, in finish_transfer_setup\n
    server_address=vc[\'address\'], logc = self.logclient)\n',
'  File "/opt/enstore/src/volume_clerk_client.py", line 255, in __init__\n
    server_name = MY_SERVER)\n', '
File "/opt/enstore/src/info_client.py", line 317, in __init__\n
rcv_tries = rcv_tries)\n',
'  File "/opt/enstore/src/generic_client.py", line 198, in __init__\n
    rcv_tries=rcv_tries)\n', '
File "/opt/enstore/src/alarm_client.py", line 72, in __init__\n
server_name = server_name)\n', '  File "/opt/enstore/src/generic_client.py",
line 129, in __init__\n    self.u = udp_client.UDPClient()\n',
'  File "/opt/enstore/src/udp_client.py", line 62, in __init__\n
self.reinit()\n', '  File "/opt/enstore/src/udp_client.py", line 70,
 in reinit\n
host, port, socket = udp_common.get_default_callback(receiver_ip=receiver_ip)\n'
, '  File "/opt/enstore/src/udp_common.py", line 88, in get_default_callback\n
    return __get_callback(host, use_port)\n',
'  File "/opt/enstore/src/udp_common.py", line 77, in __get_callback\n
raise socket.error, error_message\n'] Thread finish_transfer_setup_thread

    Note that the argument is 'fe80::ae1f:6bff:fe41:7884%eth0'
which is some IPV6 address, while the host agument is assiciated with
IPV4 address

    bz: https://www-enstore.fnal.gov/Bugzilla/show_bug.cgi?id=2484