### PR TITLE
Fix bugzilla 2358

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,7 +25,7 @@ jobs:
        export num_files=$(wc -l pytests)
        export PYTHONPATH=.:$PYTHONPATH
        echo "found  $num_files"
-       for T in $(cat pytests); do echo running $T; python $T || printf "pytest $T exited code $? "; done
+       for T in $(cat pytests); do echo running $T; python $T || printf "pytest $T exited code $?\n\n "; done
 
     - name: analysing with pylint
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint pytest
+        pip install pylint pytest mock
     - name: run unittests with pytest
       run: |
        cd src

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,7 +25,7 @@ jobs:
        export num_files=$(wc -l pytests)
        export PYTHONPATH=.:$PYTHONPATH
        echo "found  $num_files"
-       for T in $(cat pytests); do echo running $T; python $T; done
+       for T in $(cat pytests); do echo running $T; python $T || printf "pytest $T exited code $? "; done
 
     - name: analysing with pylint
       run: |

--- a/src/enstore_functions2.py
+++ b/src/enstore_functions2.py
@@ -261,10 +261,15 @@ def get_days_ago(date, days_ago):
     seconds_ago = float(days_ago*86400)
     return date - seconds_ago
 
-def ping(node):
+def ping(node, IPv=4):
     # ping the node to see if it is up.
     times_to_ping = 4
-    cmd = "ping -c %s %s" % (times_to_ping, node)
+    if IPv == 4:
+        cmd = "ping -c %s %s" % (times_to_ping, node)
+    elif IPv == 6:
+        cmd = "ping6 -c %s %s" % (times_to_ping, node)
+    else:
+        raise ValueError("%s: IPv%s does not exist" %(__file__,IPv))
     p = os.popen(cmd, 'r').readlines()
     for line in p:
         if not string.find(line, "transmitted") == -1:

--- a/src/enstore_functions2.py
+++ b/src/enstore_functions2.py
@@ -275,7 +275,9 @@ def ping(node, IPv=4):
         if not string.find(line, "transmitted") == -1:
             # this is the statistics line
             stats = string.split(line)
-            if stats[0] == stats[3] and stats[0].isdigit():
+            if stats[0] == stats[3] \
+               and stats[0].isdigit() \
+               and int(stats[0]) > 0:
                 # transmitted packets = received packets
                 return enstore_constants.IS_ALIVE
             else:

--- a/src/enstore_functions2.py
+++ b/src/enstore_functions2.py
@@ -289,7 +289,7 @@ def get_remote_file(node, remote_file, newfile):
         # this is the child
         rtn = subprocess.call("enrcp %s:%s %s" % (node, remote_file, newfile),
                               shell=True)
-        os._exit(0)
+        os._exit(rtn)
     else:
         # this is the parent, allow a total of 30 seconds for the child
         for i in [0, 1, 2, 3, 4, 5]:
@@ -303,6 +303,7 @@ def get_remote_file(node, remote_file, newfile):
             print "killing the rcp - %s" % (pid,)
             os.kill(pid, signal.SIGKILL)
             return 1
+
 # translate time.time output to a person readable format.
 # strip off the day and reorganize things a little
 YEARFMT = "%Y-%b-%d"

--- a/src/enstore_functions2.py
+++ b/src/enstore_functions2.py
@@ -275,7 +275,7 @@ def ping(node, IPv=4):
         if not string.find(line, "transmitted") == -1:
             # this is the statistics line
             stats = string.split(line)
-            if stats[0] == stats[3]:
+            if stats[0] == stats[3] and stats[0].isdigit():
                 # transmitted packets = received packets
                 return enstore_constants.IS_ALIVE
             else:

--- a/src/get_all_bytes_counter.py
+++ b/src/get_all_bytes_counter.py
@@ -6,6 +6,7 @@ import string
 import os
 import time
 import signal
+import subprocess
 import configuration_client
 import enstore_constants
 import e_errors
@@ -19,13 +20,11 @@ VQFORMATED = "VOLUME_QUOTAS_FORMATED"
 DEAD = 0
 ALIVE = 1
 
+
 def ping(node):
     # ping the node to see if it is up.
     times_to_ping = 4
-    # the timeout parameter does not work on d0ensrv2.
-    timeout = 5
-    #cmd = "ping -c %s -w %s %s"%(times_to_ping, timeout, node)
-    cmd = "ping -c %s %s"%(times_to_ping, node)
+    cmd = "ping -c %s %s" % (times_to_ping, node)
     p = os.popen(cmd, 'r').readlines()
     for line in p:
         if not string.find(line, "transmitted") == -1:
@@ -40,24 +39,27 @@ def ping(node):
         # we did not find the stat line
         return DEAD
 
-def get_remote_file(node, file, newfile):
+
+def get_remote_file(node, remote_file, newfile):
     # we have to make sure that the rcp does not hang in case the remote node is goofy
     pid = os.fork()
     if pid == 0:
         # this is the child
-        rtn = os.system("enrcp %s:%s %s"%(node, file, newfile))
+        rtn = subprocess.call("enrcp %s:%s %s"%(node, remote_file, newfile), shell=True:)
         os._exit(rtn)
     else:
         # this is the parent, allow a total of 30 seconds for the child
         for i in [0, 1, 2, 3, 4, 5]:
             rtn = os.waitpid(pid, os.WNOHANG)
             if rtn[0] == pid:
-                return rtn[1] >> 8   # pick out the top 8 bits as the return code
+                # pick out the top 8 bits as the return code
+                return rtn[1] >> 8
             time.sleep(5)
         else:
             # the child has not finished, be brutal. it may be hung
             os.kill(pid, signal.SIGKILL)
             return 1
+
 
 CTR_FILE = "enstore_system_user_data.html2"
 
@@ -85,15 +87,17 @@ if __name__ == "__main__":
     dead_nodes = []
 
     cnf_d = configuration_client.get_config_dict()
-    servers=cnf_d.get('known_config_servers',[])
+    servers = cnf_d.get('known_config_servers', [])
 
     for server in servers:
-        if (server == 'status') : continue
-        server_name,server_port = servers.get(server)
+        if (server == 'status'):
+            continue
+        server_name, server_port = servers.get(server)
         if ping(server_name) == ALIVE:
-            csc   = configuration_client.ConfigurationClient((server_name, server_port))
+            csc = configuration_client.ConfigurationClient(
+                (server_name, server_port))
             inq_d = {}
-            inq_d = csc.get(enstore_constants.INQUISITOR,3,3)
+            inq_d = csc.get(enstore_constants.INQUISITOR, 3, 3)
             if not e_errors.is_ok(inq_d):
                 dead_nodes.append(server)
                 continue
@@ -103,11 +107,12 @@ if __name__ == "__main__":
                 dead_nodes.append(server)
                 continue
 
-            inq_d = config_dict.get(enstore_constants.INQUISITOR,{})
-            html_dir = inq_d.get("html_file","/fnal/ups/prd/www_pages/enstore")
-            byte_me_file=os.path.join(html_dir,CTR_FILE)
+            inq_d = config_dict.get(enstore_constants.INQUISITOR, {})
+            html_dir = inq_d.get(
+                "html_file", "/fnal/ups/prd/www_pages/enstore")
+            byte_me_file = os.path.join(html_dir, CTR_FILE)
 
-            newfile = "/tmp/%s-%s"%(server, VQFORMATED)
+            newfile = "/tmp/%s-%s" % (server, VQFORMATED)
             rtn = get_remote_file(server_name, byte_me_file, newfile)
             if rtn == 0:
                 # read it
@@ -119,10 +124,10 @@ if __name__ == "__main__":
                     bytes = float(string.strip(parts[0]))
                     total += bytes/TB
                     total_bytes += bytes
-                    if len(parts)>1:
+                    if len(parts) > 1:
                         bytes = float(string.strip(parts[1]))
-                        active +=  bytes/TB
-                        active_bytes +=  bytes
+                        active += bytes/TB
+                        active_bytes += bytes
                     else:
                         active = total
                         active_bytes = total_bytes
@@ -132,23 +137,24 @@ if __name__ == "__main__":
                 # no info from this node
                 dead_nodes.append(server)
         else:
-	    dead_nodes.append(server)
+            dead_nodes.append(server)
     else:
-	# find out if we have any dead nodes
-	if dead_nodes:
-	    str = "(does not include "
-	    dead_nodes.sort()
-	    for server in dead_nodes:
-		str = str + server+","
-            str = str[0:-1] +")"
-	else:
-	    str = ""
+        # find out if we have any dead nodes
+        if dead_nodes:
+            str = "(does not include "
+            dead_nodes.sort()
+            for server in dead_nodes:
+                str = str + server+","
+            str = str[0:-1] + ")"
+        else:
+            str = ""
 
-	# output the total count
-	file = open(TOTAL_FILE, 'w')
-        file.write("Active: %.3f / Total: %.3f %s %s\n"%(active,total, UNITS, str))
-	file.close()
+        # output the total count
+        file = open(TOTAL_FILE, 'w')
+        file.write("Active: %.3f / Total: %.3f %s %s\n" %
+                   (active, total, UNITS, str))
+        file.close()
 
         file = open(TOTAL_BYTES_FILE, 'w')
-        file.write("%.0f / %.0f"%(total_bytes,active_bytes))
+        file.write("%.0f / %.0f" % (total_bytes, active_bytes))
         file.close()

--- a/src/get_all_bytes_counter.py
+++ b/src/get_all_bytes_counter.py
@@ -21,10 +21,16 @@ DEAD = 0
 ALIVE = 1
 
 
-def ping(node):
+def ping(node, IPv=4):
     # ping the node to see if it is up.
     times_to_ping = 4
-    cmd = "ping -c %s %s" % (times_to_ping, node)
+    if IPv == 4:
+        cmd = "ping -c %s %s" % (times_to_ping, node)
+    elif IPv == 6:
+        cmd = "ping6 -c %s %s" % (times_to_ping, node)
+    else:
+        raise TypeError("%s: IPv%s does not exist" %(__file__,IPv))
+        
     p = os.popen(cmd, 'r').readlines()
     for line in p:
         if not string.find(line, "transmitted") == -1:

--- a/src/get_all_bytes_counter.py
+++ b/src/get_all_bytes_counter.py
@@ -45,7 +45,7 @@ def get_remote_file(node, remote_file, newfile):
     pid = os.fork()
     if pid == 0:
         # this is the child
-        rtn = subprocess.call("enrcp %s:%s %s"%(node, remote_file, newfile), shell=True:)
+        rtn = subprocess.call("enrcp %s:%s %s"%(node, remote_file, newfile), shell=True)
         os._exit(rtn)
     else:
         # this is the parent, allow a total of 30 seconds for the child

--- a/src/tests/fixtures/enrcp
+++ b/src/tests/fixtures/enrcp
@@ -1,0 +1,12 @@
+#/bin/bash
+for arg in "$@"; do
+    #echo $arg
+    if [ "$arg" = "exit_0" ]; then
+        echo "$0 $@ ---> exiting status  0"
+        exit 0
+    fi
+    if [ "$arg" = "exit_1" ]; then
+        echo "$0 $@ ---> exiting status  1"
+        exit 1
+    fi
+done

--- a/src/tests/fixtures/enrcp
+++ b/src/tests/fixtures/enrcp
@@ -1,11 +1,24 @@
-#/bin/bash
+#!/bin/bash
+
+usage() {
+    echo "$0, a quick and dirty mockup of enrcp to test return code handling."
+    echo "any number of arguments accepted.  "
+    echo "if 'exit_0' in arglist, exit with return code 0.  "
+    echo "if 'exit_1' in arglist, exit with return code 1.  "
+}
+
+
+[ "$1" = "" ] && usage
+[ "$1" = "-h" ] && usage
+
 for arg in "$@"; do
     if [ "$arg" = "exit_0" ]; then
-        echo "$0 $@ ---> exiting status  0"
+        [ ! "$DEBUG" = "" ] && echo "$0 $@ ---> exiting status  0"
         exit 0
     fi
     if [ "$arg" = "exit_1" ]; then
-        echo "$0 $@ ---> exiting status  1"
+        [ ! "$DEBUG" = "" ] && echo "$0 $@ ---> exiting status  1"
         exit 1
     fi
 done
+exit 1

--- a/src/tests/fixtures/enrcp
+++ b/src/tests/fixtures/enrcp
@@ -1,6 +1,5 @@
 #/bin/bash
 for arg in "$@"; do
-    #echo $arg
     if [ "$arg" = "exit_0" ]; then
         echo "$0 $@ ---> exiting status  0"
         exit 0

--- a/src/tests/fixtures/mock_imports.py
+++ b/src/tests/fixtures/mock_imports.py
@@ -1,0 +1,7 @@
+import mock
+import sys
+sys.modules['enroute'] = mock.MagicMock()
+sys.modules['runon'] = mock.MagicMock()
+sys.modules['Interfaces'] = mock.MagicMock()
+sys.modules['hostaddr'] = mock.MagicMock()
+sys.modules['checksum'] = mock.MagicMock()

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -1,0 +1,278 @@
+import unittest
+import os
+import mock
+import sys
+sys.modules['enroute'] = mock.MagicMock()
+sys.modules['runon'] = mock.MagicMock()
+sys.modules['Interfaces'] = mock.MagicMock()
+sys.modules['hostaddr'] = mock.MagicMock()
+sys.modules['checksum'] = mock.MagicMock()
+from enstore_functions2 import get_remote_file
+from enstore_functions2 import ping
+
+
+class TestEnstoreFunctions2(unittest.TestCase):
+
+    @unittest.skip('not implemented')
+    def test__get_mode(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_bits_to_numeric(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test__get_rwx(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_bits_to_rwx(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test__get_bits(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_numeric_to_bits(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_symbolic_to_bits(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_print_list(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_get_mover_status_filename(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_get_migrator_status_filename(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_override_to_status(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_get_days_ago(self):
+        pass
+
+    def test_get_remote_file_good(self):
+        path = os.environ.get('PATH')
+        newpath = "./tests/fixtures:%s" % path
+        os.environ['PATH'] = newpath
+        rc = get_remote_file('fake_machine', 'fake_file', 'exit_0')
+        self.assertEquals(rc, 0, "get_remote_file expected rc 0, got %s" % rc)
+        os.environ['PATH'] = path
+
+    def test_get_remote_file_bad(self):
+        path = os.environ.get('PATH')
+        newpath = "./tests/fixtures:%s" % path
+        os.environ['PATH'] = newpath
+        rc = get_remote_file('fake_machine', 'fake_file', 'exit_1')
+        self.assertEquals(rc, 1, "get_remote_file expected rc 1, got %s" % rc)
+        os.environ['PATH'] = path
+
+    def test_ping_good(self):
+        DEAD = 0
+        ALIVE = 1
+        rc = ping('github.com')
+        self.assertEqual(ALIVE, rc, "test_ping to github.com did not succeed")
+
+    def test_ping_bad(self):
+        DEAD = 0
+        ALIVE = 1
+        print "\nIGNORE ping: cannot resolve some.bad.host: Unknown host'\nTODO: SUPPRESS"
+        rc = ping('some.bad.host')
+        self.assertEqual(
+            DEAD, rc, "test_ping to some.bad.host succeeded when it should not")
+
+
+
+    @unittest.skip('not implemented')
+    def test_format_time(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_format_plot_time(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_unformat_time(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_get_dir(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_strip_file_dir(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_strip_node(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_this(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_library_manager(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_udp_proxy_server(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_mover(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_migrator(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_media_changer(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_get_name(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_get_bpd_subdir(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_generic_server(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_get_status(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_shell_command(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_shell_command2(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test___get_wormhole(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test___find_config_file(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test___get_enstorerc(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test___read_enstore_conf(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test__get_value(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_default_value(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_used_default_host(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_default_host(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_used_default_port(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_default_port(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_used_default_file(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_default_file(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_expand_path(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_fullpath(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_fullpath2(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_this_host(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_on_host(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_readonly_state(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_readable_state(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_migration_state(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_migrated_state(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_migrating_state(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_migration_file_family(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_duplication_file_family(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_is_migration_related_file_family(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test___int_convert(self):
+        pass
+
+    @unittest.skip('not implemented')
+    def test_convert_version(self):
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -83,6 +83,7 @@ class TestEnstoreFunctions2(unittest.TestCase):
         rc = ping('127.0.0.1')
         self.assertEqual(ALIVE, rc, "enstore_functions2.test_ping to 127.0.0.1 did not succeed")
 
+    @unittest.skip('output distractiing and messy')
     def test_ping_bad(self):
         DEAD = 0
         ALIVE = 1

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -2,11 +2,11 @@ import unittest
 import os
 import mock
 import sys
-sys.modules['enroute'] = mock.MagicMock()
-sys.modules['runon'] = mock.MagicMock()
-sys.modules['Interfaces'] = mock.MagicMock()
-sys.modules['hostaddr'] = mock.MagicMock()
-sys.modules['checksum'] = mock.MagicMock()
+try:
+    import enroute
+except ImportError:
+    import fixtures.mock_imports
+    print "WARNING using mocked import of enstore C library" 
 from enstore_functions2 import get_remote_file
 from enstore_functions2 import ping
 
@@ -63,18 +63,24 @@ class TestEnstoreFunctions2(unittest.TestCase):
 
     def test_get_remote_file_good(self):
         path = os.environ.get('PATH')
-        newpath = "./tests/fixtures:%s" % path
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        fixture_dir = os.path.join(this_dir, 'fixtures')
+        newpath = "%s:%s" % (fixture_dir, path)
         os.environ['PATH'] = newpath
         rc = get_remote_file('fake_machine', 'fake_file', 'exit_0')
-        self.assertEquals(rc, 0, "enstore_functions2.get_remote_file expected rc 0, got %s" % rc)
+        errmsg = "enstore_functions2.get_remote_file expected rc 0, got %s"
+        self.assertEquals(rc, 0, errmsg % rc)
         os.environ['PATH'] = path
 
     def test_get_remote_file_bad(self):
         path = os.environ.get('PATH')
-        newpath = "./tests/fixtures:%s" % path
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        fixture_dir = os.path.join(this_dir, 'fixtures')
+        newpath = "%s:%s" % (fixture_dir, path)
         os.environ['PATH'] = newpath
+        errmsg = "enstore_functions2.get_remote_file expected rc 1, got %s"
         rc = get_remote_file('fake_machine', 'fake_file', 'exit_1')
-        self.assertEquals(rc, 1, "enstore_functions2.get_remote_file expected rc 1, got %s" % rc)
+        self.assertEquals(rc, 1, errmsg  % rc)
         os.environ['PATH'] = path
 
     def test_ping_good(self):

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -74,7 +74,7 @@ class TestEnstoreFunctions2(unittest.TestCase):
         newpath = "./tests/fixtures:%s" % path
         os.environ['PATH'] = newpath
         rc = get_remote_file('fake_machine', 'fake_file', 'exit_1')
-        self.assertEquals(rc, 1, "enstore_functins2.get_remote_file expected rc 1, got %s" % rc)
+        self.assertEquals(rc, 1, "enstore_functions2.get_remote_file expected rc 1, got %s" % rc)
         os.environ['PATH'] = path
 
     def test_ping_good(self):
@@ -86,7 +86,8 @@ class TestEnstoreFunctions2(unittest.TestCase):
     def test_ping_bad(self):
         DEAD = 0
         ALIVE = 1
-        print "\nIGNORE ping: cannot resolve some.bad.host: Unknown host'\nTODO: SUPPRESS"
+        print "\nIGNORE spurious 'ping: cannot resolve some.bad.host: Unknown host' error"
+        print "TODO: suppress stderr, this test is returning intended error code"
         rc = ping('some.bad.host')
         self.assertEqual(
             DEAD, rc, "enstore_functions2.test_ping to some.bad.host succeeded when it should not")

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -4,6 +4,7 @@ import mock
 import sys
 import tempfile
 import stat
+import time
 try:
     import enroute
 except ImportError:
@@ -18,6 +19,12 @@ from enstore_functions2 import bits_to_rwx
 from enstore_functions2 import _get_rwx
 from enstore_functions2 import _get_bits
 from enstore_functions2 import numeric_to_bits
+from enstore_functions2 import symbolic_to_bits
+from enstore_functions2 import print_list
+from enstore_functions2 import get_mover_status_filename
+from enstore_functions2 import get_migrator_status_filename
+from enstore_functions2 import override_to_status
+from enstore_functions2 import get_days_ago
 from enstore_functions2 import XMODE
 from enstore_functions2 import WMODE
 from enstore_functions2 import RMODE
@@ -94,29 +101,62 @@ class TestEnstoreFunctions2(unittest.TestCase):
         self.assertEqual(rc, expected, msg % (rc, expected))
 
 
-    @unittest.skip('not implemented')
     def test_symbolic_to_bits(self):
-        pass
+        rc = symbolic_to_bits("ug=rw")
+        expected = 432
+        msg = 'symbolic_to_bits got %s, expected %s'
+        self.assertEqual(rc,expected,msg%(rc,expected))
+        rc = symbolic_to_bits("u=rwx")
+        expected = stat.S_IRUSR|stat.S_IWUSR|stat.S_IXUSR
+        self.assertEqual(rc,expected,msg%(rc,expected))
 
-    @unittest.skip('not implemented')
     def test_print_list(self):
-        pass
+        a_list = ["a", "b", "c"]
+        rc = print_list(a_list)
+        expected = 'a b c'
+        msg = 'test_print returned  "%s", expected "%s"'
+        self.assertEqual(rc, expected, msg % (rc, expected))
 
-    @unittest.skip('not implemented')
+        
+
     def test_get_mover_status_filename(self):
-        pass
+        rc = get_mover_status_filename()
+        expected = "enstore_movers.html"
+        msg = 'get_mover_status_filename  returned  "%s", expected "%s"'
+        self.assertEqual(rc, expected, msg % (rc, expected))
 
-    @unittest.skip('not implemented')
     def test_get_migrator_status_filename(self):
-        pass
+        rc = get_migrator_status_filename()
+        expected = "enstore_migrators.html"
+        msg = 'get_migrator_status_filename  returned  "%s", expected "%s"'
+        self.assertEqual(rc, expected, msg % (rc, expected))
 
-    @unittest.skip('not implemented')
     def test_override_to_status(self):
-        pass
+        for sval in enstore_constants.SAAG_STATUS:
+            lval = [sval]
+            rc1 = override_to_status(sval)
+            rc2 = override_to_status(lval)
+            idx  = enstore_constants.SAAG_STATUS.index(sval)
+            rc3 = enstore_constants.REAL_STATUS[idx]
+            msg = 'enstore_constants.SAAG_STATUS mismatch to enstore_constants.REAL_STATUS'
+            self.assertEqual(rc1, rc2, msg)
+            self.assertEqual(rc2, rc3, msg)
+            
 
-    @unittest.skip('not implemented')
+
     def test_get_days_ago(self):
-        pass
+        now = time.time()
+        sec_in_day = 86400
+        msg = 'get_days_ago  returned  %s, expected %s'
+        two_days_ago = float(sec_in_day*2)
+        expected = now - two_days_ago
+        rc = get_days_ago(now, 2)
+        self.assertEqual(rc, expected, msg % (rc, expected))
+        ten_days_ago = float(sec_in_day*10)
+        expected = now - ten_days_ago
+        rc = get_days_ago(now, 10)
+        self.assertEqual(rc, expected, msg % (rc, expected))
+
 
     def test_get_remote_file_good(self):
         path = os.environ.get('PATH')

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -16,6 +16,8 @@ from enstore_functions2 import _get_mode
 from enstore_functions2 import bits_to_numeric
 from enstore_functions2 import bits_to_rwx
 from enstore_functions2 import _get_rwx
+from enstore_functions2 import _get_bits
+from enstore_functions2 import numeric_to_bits
 from enstore_functions2 import XMODE
 from enstore_functions2 import WMODE
 from enstore_functions2 import RMODE
@@ -70,13 +72,29 @@ class TestEnstoreFunctions2(unittest.TestCase):
         rc = _get_rwx(st.st_mode, stat.S_IRGRP, stat.S_IWGRP, stat.S_IXGRP)
         self.assertEqual(rc,'---')
 
-    @unittest.skip('not implemented')
     def test__get_bits(self):
-        pass
+        os.chmod(self.tf1.name, stat.S_IRUSR|stat.S_IWUSR|stat.S_IXUSR)
+        st = os.stat(self.tf1.name)
+        expected = 0
+        rc = _get_bits(0, stat.S_IRUSR, stat.S_IWUSR, stat.S_IXUSR)
+        msg = "_get_bits returned %s, expected %s"
+        self.assertEqual(rc, expected, msg % (rc, expected))
+        expected = 448
+        rc = _get_bits(st.st_mode, stat.S_IRUSR, stat.S_IWUSR, stat.S_IXUSR)
+        self.assertEqual(rc, expected, msg % (rc, expected))
 
-    @unittest.skip('not implemented')
+
+
+
     def test_numeric_to_bits(self):
-        pass
+        rc = numeric_to_bits('0700')
+        expected = stat.S_IRUSR|stat.S_IWUSR|stat.S_IXUSR
+        msg = 'numeric_to_bits got %s, expected %s'
+        self.assertEqual(rc, expected, msg % (rc, expected))
+        expected = expected | stat.S_IRWXG
+        rc =  numeric_to_bits('0770')
+        self.assertEqual(rc, expected, msg % (rc, expected))
+
 
     @unittest.skip('not implemented')
     def test_symbolic_to_bits(self):

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -138,7 +138,7 @@ class TestEnstoreFunctions2(unittest.TestCase):
 
 
     def test_ping_bad(self):
-        addr = '0.0.0.0'
+        addr = '0.0.0.1'
         rc = ping(addr)
         msg = "enstore_functions2.test_ping to %s expected %s, got %s"
         expect = enstore_constants.IS_DEAD

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -140,14 +140,16 @@ class TestEnstoreFunctions2(unittest.TestCase):
     def test_ping_bad(self):
         addr = '0.0.0.0'
         rc = ping(addr)
-        msg = "enstore_functions2.test_ping to %s succeeded, it should not"
-        self.assertEqual(enstore_constants.IS_DEAD, rc, msg % addr)
+        msg = "enstore_functions2.test_ping to %s expected %s, got %s"
+        expect = enstore_constants.IS_DEAD
+        self.assertEqual(expect, rc, msg % (addr, expect, rc))
 
     def test_ping6_bad(self):
         addr = '::0'
         rc = ping(addr, IPv=6)
-        msg = "enstore_functions2.test_ping to %s succeeded, it should not"
-        self.assertEqual(enstore_constants.IS_DEAD, rc, msg % addr)
+        msg = "enstore_functions2.test_ping to %s expected %s, got %s"
+        expect = enstore_constants.IS_DEAD
+        self.assertEqual(expect, rc, msg % (addr, expect, rc))
 
 
     def test_ping_badIPv(self):

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -80,8 +80,8 @@ class TestEnstoreFunctions2(unittest.TestCase):
     def test_ping_good(self):
         DEAD = 0
         ALIVE = 1
-        rc = ping('github.com')
-        self.assertEqual(ALIVE, rc, "enstore_functions2.test_ping to github.com did not succeed")
+        rc = ping('127.0.0.1')
+        self.assertEqual(ALIVE, rc, "enstore_functions2.test_ping to 127.0.0.1 did not succeed")
 
     def test_ping_bad(self):
         DEAD = 0

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -94,7 +94,6 @@ class TestEnstoreFunctions2(unittest.TestCase):
             DEAD, rc, "enstore_functions2.test_ping to some.bad.host succeeded when it should not")
 
 
-
     @unittest.skip('not implemented')
     def test_format_time(self):
         pass

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -66,7 +66,7 @@ class TestEnstoreFunctions2(unittest.TestCase):
         newpath = "./tests/fixtures:%s" % path
         os.environ['PATH'] = newpath
         rc = get_remote_file('fake_machine', 'fake_file', 'exit_0')
-        self.assertEquals(rc, 0, "get_remote_file expected rc 0, got %s" % rc)
+        self.assertEquals(rc, 0, "enstore_functions2.get_remote_file expected rc 0, got %s" % rc)
         os.environ['PATH'] = path
 
     def test_get_remote_file_bad(self):
@@ -74,14 +74,14 @@ class TestEnstoreFunctions2(unittest.TestCase):
         newpath = "./tests/fixtures:%s" % path
         os.environ['PATH'] = newpath
         rc = get_remote_file('fake_machine', 'fake_file', 'exit_1')
-        self.assertEquals(rc, 1, "get_remote_file expected rc 1, got %s" % rc)
+        self.assertEquals(rc, 1, "enstore_functins2.get_remote_file expected rc 1, got %s" % rc)
         os.environ['PATH'] = path
 
     def test_ping_good(self):
         DEAD = 0
         ALIVE = 1
         rc = ping('github.com')
-        self.assertEqual(ALIVE, rc, "test_ping to github.com did not succeed")
+        self.assertEqual(ALIVE, rc, "enstore_functions2.test_ping to github.com did not succeed")
 
     def test_ping_bad(self):
         DEAD = 0
@@ -89,7 +89,7 @@ class TestEnstoreFunctions2(unittest.TestCase):
         print "\nIGNORE ping: cannot resolve some.bad.host: Unknown host'\nTODO: SUPPRESS"
         rc = ping('some.bad.host')
         self.assertEqual(
-            DEAD, rc, "test_ping to some.bad.host succeeded when it should not")
+            DEAD, rc, "enstore_functions2.test_ping to some.bad.host succeeded when it should not")
 
 
 

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -84,8 +84,6 @@ class TestEnstoreFunctions2(unittest.TestCase):
         self.assertEqual(rc, expected, msg % (rc, expected))
 
 
-
-
     def test_numeric_to_bits(self):
         rc = numeric_to_bits('0700')
         expected = stat.S_IRUSR|stat.S_IWUSR|stat.S_IXUSR

--- a/src/tests/test_enstore_functions2.py
+++ b/src/tests/test_enstore_functions2.py
@@ -25,6 +25,19 @@ from enstore_functions2 import get_mover_status_filename
 from enstore_functions2 import get_migrator_status_filename
 from enstore_functions2 import override_to_status
 from enstore_functions2 import get_days_ago
+from enstore_functions2 import format_time
+from enstore_functions2 import unformat_time
+from enstore_functions2 import format_plot_time
+from enstore_functions2 import get_dir
+from enstore_functions2 import strip_file_dir
+from enstore_functions2 import strip_node
+from enstore_functions2 import is_this
+from enstore_functions2 import is_library_manager
+from enstore_functions2 import is_udp_proxy_server
+from enstore_functions2 import is_mover
+from enstore_functions2 import is_media_changer
+from enstore_functions2 import is_migrator
+from enstore_functions2 import get_name
 from enstore_functions2 import XMODE
 from enstore_functions2 import WMODE
 from enstore_functions2 import RMODE
@@ -213,57 +226,82 @@ class TestEnstoreFunctions2(unittest.TestCase):
         with self.assertRaises(ValueError):
             rc = ping(addr, IPv=99)
 
-    @unittest.skip('not implemented')
-    def test_format_time(self):
-        pass
+    def test_format_and_unformattime(self):
+        now = long(time.time())
+        fmted = format_time(now)
+        expected = long(unformat_time(fmted))
+        msg = "format_time unformat_time disagree returned %s expected %s"
+        self.assertEqual(now, expected, msg %(expected, now))
 
-    @unittest.skip('not implemented')
     def test_format_plot_time(self):
-        pass
+        now = time.time()
+        rc = format_plot_time(now)
+        self.assertNotEqual(rc,None)
+        self.assertNotEqual(rc,'')
 
-    @unittest.skip('not implemented')
-    def test_unformat_time(self):
-        pass
 
-    @unittest.skip('not implemented')
     def test_get_dir(self):
-        pass
+        expected = os.getcwd()
+        rc = get_dir(expected)
+        self.assertEqual(rc, expected)
+        inp = expected+'/foo/bar/'
+        expected = inp[:-1]
+        rc = get_dir(inp)
+        self.assertEqual(rc, expected)
 
-    @unittest.skip('not implemented')
     def test_strip_file_dir(self):
-        pass
+        inp = "/the/deep/deep/deep/dir"
+        expected = "dir"
+        rc = strip_file_dir(inp)
+        self.assertEqual(expected, rc)
 
-    @unittest.skip('not implemented')
     def test_strip_node(self):
-        pass
+        inp = 'somenode.fnal.gov'
+        expected = 'somenode'
+        rc = strip_node(inp)
+        self.assertEqual(rc,expected)
+        inp = None
+        expected = None
+        rc = strip_node(inp)
+        self.assertEqual(inp,expected)
 
-    @unittest.skip('not implemented')
     def test_is_this(self):
-        pass
+        input = 'aview.of.reality'
+        self.assertTrue(is_this(input,'reality'))
+        self.assertFalse(is_this(input,'fantasy'))
 
-    @unittest.skip('not implemented')
     def test_is_library_manager(self):
-        pass
+        input1 = 'this.is.library_manager'
+        input2 = 'this.is.not_library_manager'
+        self.assertTrue(is_library_manager(input1))
+        self.assertFalse(is_library_manager(input2))
 
-    @unittest.skip('not implemented')
     def test_is_udp_proxy_server(self):
-        pass
+        input1 = 'this.is.udp_proxy_server'
+        input2 = 'this.is.not_udp_proxy_server'
+        self.assertTrue(is_udp_proxy_server(input1))
+        self.assertFalse(is_udp_proxy_server(input2))
 
-    @unittest.skip('not implemented')
     def test_is_mover(self):
-        pass
+        input1 = 'this.is.mover'
+        input2 = 'this.is.not_mover'
+        self.assertTrue(is_mover(input1))
+        self.assertFalse(is_mover(input2))
 
-    @unittest.skip('not implemented')
     def test_is_migrator(self):
-        pass
+        input1 = 'this.is.migrator'
+        input2 = 'this.is.not_migrator'
+        self.assertTrue(is_migrator(input1))
+        self.assertFalse(is_migrator(input2))
 
-    @unittest.skip('not implemented')
     def test_is_media_changer(self):
-        pass
+        input1 = 'this.is.media_changer'
+        input2 = 'this.is.not_media_changer'
+        self.assertTrue(is_media_changer(input1))
+        self.assertFalse(is_media_changer(input2))
 
-    @unittest.skip('not implemented')
     def test_get_name(self):
-        pass
+        self.assertEqual('foo',get_name('foo.bar.baz'))
 
     @unittest.skip('not implemented')
     def test_get_bpd_subdir(self):

--- a/src/tests/test_get_all_bytes_counter.py
+++ b/src/tests/test_get_all_bytes_counter.py
@@ -33,8 +33,8 @@ class TestGetAllBytesCounter(unittest.TestCase):
     def test_ping_good(self):
         DEAD = 0
         ALIVE = 1
-        rc = ping('github.com')
-        self.assertEqual(ALIVE, rc, "get_all_bytes_counter.test_ping to github.com did not succeed")
+        rc = ping('127.0.0.1')
+        self.assertEqual(ALIVE, rc, "get_all_bytes_counter.test_ping to 127.0.0.1 did not succeed")
 
     def test_ping_bad(self):
         DEAD = 0

--- a/src/tests/test_get_all_bytes_counter.py
+++ b/src/tests/test_get_all_bytes_counter.py
@@ -49,9 +49,9 @@ class TestGetAllBytesCounter(unittest.TestCase):
         DEAD = 0
         ALIVE = 1
         # havent figured out how to suppress ping output to stderr
-        rc = ping('0.0.0.0')
+        rc = ping('0.0.0.1')
         self.assertEqual(
-            DEAD, rc, "test_ping to 0.0.0.0 succeeded when it should not")
+            DEAD, rc, "test_ping to 0.0.0.1 succeeded when it should not")
 
 
 if __name__ == "__main__":

--- a/src/tests/test_get_all_bytes_counter.py
+++ b/src/tests/test_get_all_bytes_counter.py
@@ -42,16 +42,16 @@ class TestGetAllBytesCounter(unittest.TestCase):
     def test_ping_good(self):
         DEAD = 0
         ALIVE = 1
-        rc = ping('github.com')
-        self.assertEqual(ALIVE, rc, "test_ping to github.com did not succeed")
+        rc = ping('127.0.0.1')
+        self.assertEqual(ALIVE, rc, "test_ping to 127.0.0.1 did not succeed")
 
     def test_ping_bad(self):
         DEAD = 0
         ALIVE = 1
         # havent figured out how to suppress ping output to stderr
-        rc = ping('some.bad.host')
+        rc = ping('0.0.0.0')
         self.assertEqual(
-            DEAD, rc, "test_ping to some.bad.host succeeded when it should not")
+            DEAD, rc, "test_ping to 0.0.0.0 succeeded when it should not")
 
 
 if __name__ == "__main__":

--- a/src/tests/test_get_all_bytes_counter.py
+++ b/src/tests/test_get_all_bytes_counter.py
@@ -39,7 +39,8 @@ class TestGetAllBytesCounter(unittest.TestCase):
     def test_ping_bad(self):
         DEAD = 0
         ALIVE = 1
-        print "\nIGNORE ping: cannot resolve some.bad.host: Unknown host'\nTODO: SUPPRESS"
+        print "\nIGNORE spurious 'ping: cannot resolve some.bad.host: Unknown host' error"
+        print "TODO: suppress stderr, this test is returning intended error code"
         rc = ping('some.bad.host')
         self.assertEqual(
             DEAD, rc, "get_all_bytes_counter.test_ping to some.bad.host succeeded when it should not")

--- a/src/tests/test_get_all_bytes_counter.py
+++ b/src/tests/test_get_all_bytes_counter.py
@@ -1,0 +1,49 @@
+import unittest
+import os
+import mock
+import sys
+import StringIO
+sys.modules['enroute'] = mock.MagicMock()
+sys.modules['runon'] = mock.MagicMock()
+sys.modules['Interfaces'] = mock.MagicMock()
+sys.modules['hostaddr'] = mock.MagicMock()
+sys.modules['checksum'] = mock.MagicMock()
+from get_all_bytes_counter import get_remote_file
+from get_all_bytes_counter import ping
+
+
+class TestGetAllBytesCounter(unittest.TestCase):
+
+    def test_get_remote_file_good(self):
+        path = os.environ.get('PATH')
+        newpath = "./tests/fixtures:%s" % path
+        os.environ['PATH'] = newpath
+        rc = get_remote_file('fake_machine', 'fake_file', 'exit_0')
+        self.assertEquals(rc, 0, "get_remote_file expected rc 0, got %s" % rc)
+        os.environ['PATH'] = path
+
+    def test_get_remote_file_bad(self):
+        path = os.environ.get('PATH')
+        newpath = "./tests/fixtures:%s" % path
+        os.environ['PATH'] = newpath
+        rc = get_remote_file('fake_machine', 'fake_file', 'exit_1')
+        self.assertEquals(rc, 1, "get_remote_file expected rc 1, got %s" % rc)
+        os.environ['PATH'] = path
+
+    def test_ping_good(self):
+        DEAD = 0
+        ALIVE = 1
+        rc = ping('github.com')
+        self.assertEqual(ALIVE, rc, "test_ping to github.com did not succeed")
+
+    def test_ping_bad(self):
+        DEAD = 0
+        ALIVE = 1
+        print "\nIGNORE ping: cannot resolve some.bad.host: Unknown host'\nTODO: SUPPRESS"
+        rc = ping('some.bad.host')
+        self.assertEqual(
+            DEAD, rc, "test_ping to some.bad.host succeeded when it should not")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_get_all_bytes_counter.py
+++ b/src/tests/test_get_all_bytes_counter.py
@@ -19,7 +19,7 @@ class TestGetAllBytesCounter(unittest.TestCase):
         newpath = "./tests/fixtures:%s" % path
         os.environ['PATH'] = newpath
         rc = get_remote_file('fake_machine', 'fake_file', 'exit_0')
-        self.assertEquals(rc, 0, "get_remote_file expected rc 0, got %s" % rc)
+        self.assertEquals(rc, 0, "get_all_bytes_counter.get_remote_file expected rc 0, got %s" % rc)
         os.environ['PATH'] = path
 
     def test_get_remote_file_bad(self):
@@ -27,14 +27,14 @@ class TestGetAllBytesCounter(unittest.TestCase):
         newpath = "./tests/fixtures:%s" % path
         os.environ['PATH'] = newpath
         rc = get_remote_file('fake_machine', 'fake_file', 'exit_1')
-        self.assertEquals(rc, 1, "get_remote_file expected rc 1, got %s" % rc)
+        self.assertEquals(rc, 1, "get_all_bytes_counter.get_remote_file expected rc 1, got %s" % rc)
         os.environ['PATH'] = path
 
     def test_ping_good(self):
         DEAD = 0
         ALIVE = 1
         rc = ping('github.com')
-        self.assertEqual(ALIVE, rc, "test_ping to github.com did not succeed")
+        self.assertEqual(ALIVE, rc, "get_all_bytes_counter.test_ping to github.com did not succeed")
 
     def test_ping_bad(self):
         DEAD = 0
@@ -42,7 +42,7 @@ class TestGetAllBytesCounter(unittest.TestCase):
         print "\nIGNORE ping: cannot resolve some.bad.host: Unknown host'\nTODO: SUPPRESS"
         rc = ping('some.bad.host')
         self.assertEqual(
-            DEAD, rc, "test_ping to some.bad.host succeeded when it should not")
+            DEAD, rc, "get_all_bytes_counter.test_ping to some.bad.host succeeded when it should not")
 
 
 if __name__ == "__main__":

--- a/src/tests/test_get_all_bytes_counter.py
+++ b/src/tests/test_get_all_bytes_counter.py
@@ -1,13 +1,14 @@
 import unittest
 import os
-import mock
 import sys
+import mock
 import StringIO
-sys.modules['enroute'] = mock.MagicMock()
-sys.modules['runon'] = mock.MagicMock()
-sys.modules['Interfaces'] = mock.MagicMock()
-sys.modules['hostaddr'] = mock.MagicMock()
-sys.modules['checksum'] = mock.MagicMock()
+try:
+    import enroute
+except ImportError:
+    import fixtures.mock_imports
+    sys.stderr.write("WARNING using mocked import of enstore C library\n")
+
 from get_all_bytes_counter import get_remote_file
 from get_all_bytes_counter import ping
 
@@ -16,35 +17,41 @@ class TestGetAllBytesCounter(unittest.TestCase):
 
     def test_get_remote_file_good(self):
         path = os.environ.get('PATH')
-        newpath = "./tests/fixtures:%s" % path
+        # put a dummy enrcp in path
+        # just so get_remote_file() has a return code to test
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        fixture_dir = os.path.join(this_dir, 'fixtures')
+        newpath = "%s:%s" % (fixture_dir, path)
         os.environ['PATH'] = newpath
         rc = get_remote_file('fake_machine', 'fake_file', 'exit_0')
-        self.assertEquals(rc, 0, "get_all_bytes_counter.get_remote_file expected rc 0, got %s" % rc)
+        self.assertEquals(rc, 0, "get_remote_file expected rc 0, got %s" % rc)
         os.environ['PATH'] = path
 
     def test_get_remote_file_bad(self):
         path = os.environ.get('PATH')
-        newpath = "./tests/fixtures:%s" % path
+        # put a dummy enrcp in path
+        # just so get_remote_file() has a return code to test
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        fixture_dir = os.path.join(this_dir, 'fixtures')
+        newpath = "%s:%s" % (fixture_dir, path)
         os.environ['PATH'] = newpath
         rc = get_remote_file('fake_machine', 'fake_file', 'exit_1')
-        self.assertEquals(rc, 1, "get_all_bytes_counter.get_remote_file expected rc 1, got %s" % rc)
+        self.assertEquals(rc, 1, "get_remote_file expected rc 1, got %s" % rc)
         os.environ['PATH'] = path
 
     def test_ping_good(self):
         DEAD = 0
         ALIVE = 1
-        rc = ping('127.0.0.1')
-        self.assertEqual(ALIVE, rc, "get_all_bytes_counter.test_ping to 127.0.0.1 did not succeed")
+        rc = ping('github.com')
+        self.assertEqual(ALIVE, rc, "test_ping to github.com did not succeed")
 
-    @unittest.skip('output distractiing and messy')
     def test_ping_bad(self):
         DEAD = 0
         ALIVE = 1
-        print "\nIGNORE spurious 'ping: cannot resolve some.bad.host: Unknown host' error"
-        print "TODO: suppress stderr, this test is returning intended error code"
+        # havent figured out how to suppress ping output to stderr
         rc = ping('some.bad.host')
         self.assertEqual(
-            DEAD, rc, "get_all_bytes_counter.test_ping to some.bad.host succeeded when it should not")
+            DEAD, rc, "test_ping to some.bad.host succeeded when it should not")
 
 
 if __name__ == "__main__":

--- a/src/tests/test_get_all_bytes_counter.py
+++ b/src/tests/test_get_all_bytes_counter.py
@@ -36,6 +36,7 @@ class TestGetAllBytesCounter(unittest.TestCase):
         rc = ping('127.0.0.1')
         self.assertEqual(ALIVE, rc, "get_all_bytes_counter.test_ping to 127.0.0.1 did not succeed")
 
+    @unittest.skip('output distractiing and messy')
     def test_ping_bad(self):
         DEAD = 0
         ALIVE = 1


### PR DESCRIPTION
see CI pytest output of ddbox/enstore branches test_bugzilla-2358 and fix_bugzilla-2358.
This change fixes incorrect return code of get_remote_file() in get_all_bytes_counter.py and enstore_functions2.py when wrapped enrcp command returns nonzero status