### PR TITLE
Pylint enstore py

### DIFF
--- a/.github/scripts/data/enstore.repo
+++ b/.github/scripts/data/enstore.repo
@@ -1,0 +1,7 @@
+[enstore]
+name=Enstore
+baseurl=https://ssasrv1.fnal.gov/en/slf7x/x86_64
+enabled=1
+gpgcheck=0
+priority=85
+sslverify=0

--- a/.github/scripts/data/setup-enstore
+++ b/.github/scripts/data/setup-enstore
@@ -1,0 +1,107 @@
+#!/bin/bash
+# source this file to set enstore environment
+# Function definitions
+# Add [default: prepend] arg1 to PATH only once thus this file can be sourced multiple times.
+# Use 2nd argument "after" to append arg1 to $PATH.
+# Do not mess with pathmunge (unset) in /etc/profile
+_pathmunge() {
+    if ! [[ $PATH =~ (^|:)$1($|:) ]] ; then
+        if [[ ${2:-} == after ]] ; then
+            PATH=$PATH:$1;
+        else
+            PATH=$1:$PATH;
+        fi
+    fi
+}
+# where is enstore code?
+rpm -q enstore > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Enstore rpm is not installed"
+    # if executed - exit, if sourced - return :
+    [[ x"${BASH_SOURCE[0]}" == x"$0" ]] && exit 1 || return 1
+fi
+export ENSTORE_DIR=/$(rpm -q --queryformat "%{instprefixes}\n" enstore)
+# Directories for enstore submodules and tools
+export PYTHON_DIR=$ENSTORE_DIR/Python
+export FTT_DIR=$ENSTORE_DIR/FTT
+export SWIG_DIR=$ENSTORE_DIR/SWIG
+export SWIG_LIB=$SWIG_DIR/swig_lib
+export QPID_DIR=$ENSTORE_DIR/qpid
+# These use absolute paths:
+export ENSTORE_OUT=/var/log/enstore
+export FARMLETS_DIR=/usr/local/etc/farmlets
+# build PATH:
+_pathmunge $SWIG_DIR
+_pathmunge $QPID_DIR/bin
+_pathmunge $ENSTORE_DIR/tools
+_pathmunge $ENSTORE_DIR/bin
+_pathmunge $ENSTORE_DIR/sbin
+_pathmunge $PYTHON_DIR/bin
+unset _pathmunge
+# definitions for python installed in enstore subtree
+export PYTHONINC=$(ls -d $PYTHON_DIR/include/python*)
+export PYTHONLIB=$(ls -d $PYTHON_DIR/lib/python*)
+export PYTHONPATH=$ENSTORE_DIR:$ENSTORE_DIR/src:$ENSTORE_DIR/modules:$ENSTORE_DIR/HTMLgen:$ENSTORE_DIR/PyGreSQL
+export PYTHONUNBUFFERED="x";
+export GADFLY_GRAMMAR=$ENSTORE_DIR/gadfly
+# These urls are used to configure git to point to central enstore repositories at FNAL.
+#   ENSTORE_GIT - for code
+#   ENSTORE_CONF_GIT - site specific configuration
+# Once repository configured, you operate through remote alias and do not need this anymore
+# Example:
+#   git clone -o enstore ${ENSTORE_GIT}
+export ENSTORE_GIT=ssh://p-enstore@cdgit.fnal.gov/cvs/projects/enstore
+export ENSTORE_CONF_GIT=ssh://p-enstore-config@cdgit.fnal.gov/cvs/projects/enstore-config
+# Keep this around while mod_config operates with configuration in CVS
+export CVSROOT=hppccvs@cdcvs.fnal.gov:/cvs/hppc
+export CVS_RSH=ssh
+# if using ssh for enstore node communications for distribution, upgrade, and maintenance
+# uncomment the following lines
+#export ENSSH=/usr/bin/ssh
+#export ENSCP=/usr/bin/scp
+#-----------------------------------------------------------------------------------------
+# Enstore site specific configuration files
+# These files come from enstore-config git repository
+# ENSTORE_HOME=/home/enstore is referenced as default location at /usr/local/etc/setups.sh
+export ENSTORE_HOME=${ENSTORE_HOME:-/home/enstore}
+export HOME=${HOME:-${ENSTORE_HOME}} # set if does not exist such as for cgi
+export ENSTORE_CONFIG_DIR=${ENSTORE_HOME}/site_specific
+# Customize settings between enstore systems at fnal.
+# The files are looked at ${ENSTORE_CONFIG_DIR}/config
+# Try to source setup-enstore.local if it exist
+# if it did not set ENSTORE_CONFIG_HOST try to set env  with chooseConfig
+#
+# The customization script shall look like:
+# enstore-setup.local :
+#   ENSTORE_CONFIG_HOST=stkensrv2n.fnal.gov
+#   ENSTORE_CONFIG_FILE=${ENSTORE_CONFIG_DIR}/stk.conf
+#   ENSTORE_MAIL=enstore-auto@fnal.gov
+#
+# There are preconfigured files for existing systems like
+#   enstore-setup.stken :
+# During enstore installation/configuration this or similar script shall be copied to enstore-setup.local
+#
+# If someone need to customize one node only, create file like setup-enstore.dmsen02
+#   enstore-setup.local is ignored in this case.
+# See file setup-enstore.README for further details.
+# Defaults:
+ENSTORE_CONFIG_PORT=7500
+ENSTORE_MAIL=enstore-auto@fnal.gov
+# Customize for local subsystem
+if [[ -r ${ENSTORE_CONFIG_DIR}/config/setup-enstore.local ]]; then
+    source ${ENSTORE_CONFIG_DIR}/config/setup-enstore.local
+fi
+# Customization scripts do not exist, or they failed to set ENSTORE_CONFIG_HOST
+if [[ ${ENSTORE_CONFIG_HOST:-x} == "x" ]]
+then
+    # These are default settings used to choose between system installations at fnal:
+    ENSTORE_CONFIG_HOST=$($ENSTORE_DIR/ups/chooseConfig)
+    ENSTORE_CONFIG_FILE=${ENSTORE_CONFIG_DIR}/config/$($ENSTORE_DIR/ups/chooseConfig file)
+    ENSTORE_MAIL=$($ENSTORE_DIR/ups/chooseConfig mail)
+fi
+export ENSTORE_GANG ENSTORE_CONFIG_HOST ENSTORE_CONFIG_PORT ENSTORE_CONFIG_FILE ENSTORE_MAIL
+[[ ${ENSTORE_SFA_POLICY:-x} == "x" ]] || export ENSTORE_SFA_POLICY
+# Execute:
+$ENSTORE_DIR/external_distr/update_sym_links.sh -c
+# if executed - exit, if sourced - return :
+[[ x"${BASH_SOURCE[0]}" == x"$0" ]] && exit 0 || return 0

--- a/.github/scripts/install-enstore.sh
+++ b/.github/scripts/install-enstore.sh
@@ -1,0 +1,6 @@
+apt update -y
+apt install -y yum-utils
+cp data/enstore.repo /etc/yum.repos.d/enstore.repo
+yum update -y
+yum install -y enstore
+cp data/setup-enstore /tmp/setup-enstore

--- a/.github/workflows/pylint-enstore-py.yml
+++ b/.github/workflows/pylint-enstore-py.yml
@@ -14,10 +14,16 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install enstore
+      run: |
+       sudo ./.github/scripts/install-enstore.sh
+       source /tmp/setup-enstore
+      shell: bash
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install pylint pytest
+       source /tmp/setup-enstore
+       python -m pip install --upgrade pip
+       pip install pylint pytest
     - name: run unittests with pytest
       run: |
        cd src
@@ -26,7 +32,6 @@ jobs:
        export PYTHONPATH=.:$PYTHONPATH
        echo "found  $num_files"
        for T in $(cat pytests); do echo running $T; python $T; done
-
     - name: analysing with pylint
       run: |
        find . -name '*.py' > python_files

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -16,30 +16,30 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install enstore
       run: |
-        sudo ./.github/scripts/install-enstore.sh
-        source /tmp/setup-enstore
+       sudo ./.github/scripts/install-enstore.sh
+       source /tmp/setup-enstore
       shell: bash
     - name: Install dependencies
       run: |
-        source /tmp/setup-enstore
-        python -m pip install --upgrade pip
-        pip install pylint pytest
+       source /tmp/setup-enstore
+       python -m pip install --upgrade pip
+       pip install pylint pytest
     - name: run unittests with pytest
       run: |
-        cd src
-        find . -name 'test_*.py' > pytests
-        export num_files=$(wc -l pytests)
-        export PYTHONPATH=.:$PYTHONPATH
-        echo "found  $num_files"
-        for T in $(cat pytests); do echo running $T; python $T; done
+       cd src
+       find . -name 'test_*.py' > pytests
+       export num_files=$(wc -l pytests)
+       export PYTHONPATH=.:$PYTHONPATH
+       echo "found  $num_files"
+       for T in $(cat pytests); do echo running $T; python $T; done
     - name: analysing with pylint
       run: |
-        find . -name '*.py' > python_files
-        export num_files=$(wc -l python_files)
-        export opts=' --disable=all --enable=syntax-error'
-        export opts=$opts' --enable=bad-thread-instantiation'
-        export opts=$opts' --enable=used-before-assignment'
-        export opts=$opts' --enable=undefined-variable --score no'
-        echo "found $num_files "
-        for P in $(cat python_files) ; do  pylint $opts $P 2>/dev/null || printf "pylint $P exited code $?\n\n"   ; done
-        echo "linted $num_files "
+       find . -name '*.py' > python_files
+       export num_files=$(wc -l python_files)
+       export opts=' --disable=all --enable=syntax-error'
+       export opts=$opts' --enable=bad-thread-instantiation'
+       export opts=$opts' --enable=used-before-assignment'
+       export opts=$opts' --enable=undefined-variable --score no'
+       echo "found $num_files "
+       for P in $(cat python_files) ; do  pylint $opts $P 2>/dev/null || printf "pylint $P exited code $?\n\n"   ; done
+       echo "linted $num_files "

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,27 +14,32 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install enstore
+      run: |
+        sudo ./.github/scripts/install-enstore.sh
+        source /tmp/setup-enstore
+      shell: bash
     - name: Install dependencies
       run: |
+        source /tmp/setup-enstore
         python -m pip install --upgrade pip
         pip install pylint pytest
     - name: run unittests with pytest
       run: |
-       cd src
-       find . -name 'test_*.py' > pytests
-       export num_files=$(wc -l pytests)
-       export PYTHONPATH=.:$PYTHONPATH
-       echo "found  $num_files"
-       for T in $(cat pytests); do echo running $T; python $T; done
-
+        cd src
+        find . -name 'test_*.py' > pytests
+        export num_files=$(wc -l pytests)
+        export PYTHONPATH=.:$PYTHONPATH
+        echo "found  $num_files"
+        for T in $(cat pytests); do echo running $T; python $T; done
     - name: analysing with pylint
       run: |
-       find . -name '*.py' > python_files
-       export num_files=$(wc -l python_files)
-       export opts=' --disable=all --enable=syntax-error'
-       export opts=$opts' --enable=bad-thread-instantiation'
-       export opts=$opts' --enable=used-before-assignment'
-       export opts=$opts' --enable=undefined-variable --score no'
-       echo "found $num_files "
-       for P in $(cat python_files) ; do  pylint $opts $P 2>/dev/null || printf "pylint $P exited code $?\n\n"   ; done
-       echo "linted $num_files "
+        find . -name '*.py' > python_files
+        export num_files=$(wc -l python_files)
+        export opts=' --disable=all --enable=syntax-error'
+        export opts=$opts' --enable=bad-thread-instantiation'
+        export opts=$opts' --enable=used-before-assignment'
+        export opts=$opts' --enable=undefined-variable --score no'
+        echo "found $num_files "
+        for P in $(cat python_files) ; do  pylint $opts $P 2>/dev/null || printf "pylint $P exited code $?\n\n"   ; done
+        echo "linted $num_files "


### PR DESCRIPTION
Create new pylint workflow that installs the Enstore RPM in its VM and uses the Python version therein to run pytest / pylint.

This is to resolve issues importing C modules with other versions of Python