### PR TITLE
Add pytests for some Enstore src modules

### DIFF
--- a/.github/docker/cc7-enstore/Dockerfile
+++ b/.github/docker/cc7-enstore/Dockerfile
@@ -5,4 +5,4 @@ ADD data/* data/
 
 RUN cp data/enstore.repo /etc/yum.repos.d/enstore.repo
 RUN yum update -y && yum install -y enstore tk
-RUN source data/setup-enstore && python -m pip install pytest pylint mock
+RUN source data/setup-enstore && python -m pip install pytest pylint pyfakefs mock

--- a/src/module_trace.py
+++ b/src/module_trace.py
@@ -10,130 +10,130 @@ mtable = {}
 rm_table = {}
 
 def get_module_file(m):
-  """Takes module name, returns path to the implementation file."""
-  for i in sys.path:
-    p = os.path.join(i, m+'.py')
-    if os.access(p, os.R_OK):
-      return p
-    p = os.path.join(i, m+'.so')
-    if os.access(p, os.R_OK):
-      return p
-    p = os.path.join(i, m+'module.c')
-    if os.access(p, os.R_OK):
-      return p
-  return None
+    """Takes module name, returns path to the implementation file."""
+    for i in sys.path:
+        p = os.path.join(i, m+'.py')
+        if os.access(p, os.R_OK):
+            return p
+        p = os.path.join(i, m+'.so')
+        if os.access(p, os.R_OK):
+            return p
+        p = os.path.join(i, m+'module.c')
+        if os.access(p, os.R_OK):
+            return p
+    return None
 
 def mtrace(m):
-  """Takes module name, adds imported modules recursively to mtable."""
-  if mtable.has_key(m):
-    return
-  mtable[m] = []
-  mf = get_module_file(m)
-  if mf == None:
-    return
-  f = open(mf)
-  l = f.readline()
-  while l:
-    # Skipping doc strings at beginning of file
-    idx = string.find(l, '"""')
-    if idx != -1 and idx == string.rfind(l, '"""'):
-      l = f.readline()
-      while l and string.find(l, '"""') == -1:
-        l = f.readline()
-    # If there are no more lines, exit
-    if not l:
-      break
-    # Sanitize line and split into tokens
-    l = string.strip(l)
-    l = string.replace(l, ',', ' ')
-    token = string.split(l)
-    tl = len(token)
-    i = 0
-    # Iterate over tokens
-    while i < tl:
-      # Skip to next line if we hit a commnet
-      if token[i][0] == '#': # comment
-        break
-      # If line is `from <mod> import *`
-      if (token[i] == 'from' or token[i] == '"from') \
-        and i +2 < tl and token[i+2] == 'import':
-        module = token[i+1]
-        # Add mod to mtable and recurse
-        if not module in mtable[m]:
-          mtable[m].append(module)
-        mtrace(module)
-        # Move past 'from <mod>'
-        i = i + 2
-      # If line is `import <mod>[,<mod>]*`
-      elif token[i] == 'import':
-        # Iterate over further tokens
-        for j in token[i+1:]:
-          # Exit if we hit a commnet
-          if j[0] == '#': # comment
-            break
-          module = j
-          if module[-1] == ',':
-            module = module[:-1]
-          # Add mod to mtable and recurse
-          if not module in mtable[m]:
-            mtable[m].append(module)
-          mtrace(module)
-          # Move to next mod
-          i = i + 1
-      # Go to next token
-      i = i + 1
-    # Go to next line
+    """Takes module name, adds imported modules recursively to mtable."""
+    if mtable.has_key(m):
+        return
+    mtable[m] = []
+    mf = get_module_file(m)
+    if mf == None:
+        return
+    f = open(mf)
     l = f.readline()
+    while l:
+        # Skipping doc strings at beginning of file
+        idx = string.find(l, '"""')
+        if idx != -1 and idx == string.rfind(l, '"""'):
+            l = f.readline()
+            while l and string.find(l, '"""') == -1:
+                l = f.readline()
+        # If there are no more lines, exit
+        if not l:
+            break
+        # Sanitize line and split into tokens
+        l = string.strip(l)
+        l = string.replace(l, ',', ' ')
+        token = string.split(l)
+        tl = len(token)
+        i = 0
+        # Iterate over tokens
+        while i < tl:
+            # Skip to next line if we hit a commnet
+            if token[i][0] == '#': # comment
+                break
+            # If line is `from <mod> import *`
+            if (token[i] == 'from' or token[i] == '"from') \
+                and i +2 < tl and token[i+2] == 'import':
+                module = token[i+1]
+                # Add mod to mtable and recurse
+                if not module in mtable[m]:
+                    mtable[m].append(module)
+                mtrace(module)
+                # Move past 'from <mod>'
+                i = i + 2
+            # If line is `import <mod>[,<mod>]*`
+            elif token[i] == 'import':
+                # Iterate over further tokens
+                for j in token[i+1:]:
+                    # Exit if we hit a commnet
+                    if j[0] == '#': # comment
+                        break
+                    module = j
+                    if module[-1] == ',':
+                        module = module[:-1]
+                    # Add mod to mtable and recurse
+                    if not module in mtable[m]:
+                        mtable[m].append(module)
+                    mtrace(module)
+                    # Move to next mod
+                    i = i + 1
+            # Go to next token
+            i = i + 1
+        # Go to next line
+        l = f.readline()
 
 counter = 0
 
 def log_trace(t):
-  """Stores the impot path (t) to a module (t[-1]) rm_table[t[-1]]"""
-  if not rm_table.has_key(t[-1]) or len(t) < len(rm_table[t[-1]]):
-      rm_table[t[-1]] = t
+    """Stores the impot path (t) to a module (t[-1]) rm_table[t[-1]]"""
+    if not rm_table.has_key(t[-1]) or len(t) < len(rm_table[t[-1]]):
+        rm_table[t[-1]] = t
 
 def trace_path(history, module):
-  """Explore module tree imported by a module.
+    """Explore module tree imported by a module.
 
-  Given a module, explores the module tree imported by that module according to mtable, and adds the route to each module to rm_table.
+    Given a module, explores the module tree imported by that module according to mtable, and adds the route to each module to rm_table.
   
-  Args:
-  module: The name of the module who's import tree should be explored.
-    This module should already be in mtable.
-  history: Set of modules which should be included 'above' the module passed,
-    i.a. its ancestors.
-  """
-  global counter
-  counter = counter + 1
-  # print counter, `history`, module
-  # if counter > 100:
-  #  return
-  if module in history:
-    log_trace(history+[module])
-    return
+    Args:
+    module: The name of the module who's import tree should be explored.
+      This module should already be in mtable.
+    history: Set of modules which should be included 'above' the module passed,
+      i.a. its ancestors.
+    """
+    global counter
+    counter = counter + 1
+    # print counter, `history`, module
+    # if counter > 100:
+    #  return
+    if module in history:
+        log_trace(history+[module])
+        return
 
-  if mtable.has_key(module):
-    a = history + [module]
-    for i in mtable[module]:
-      trace_path(a, i)
-    log_trace(a)
+    if mtable.has_key(module):
+        a = history + [module]
+        for i in mtable[module]:
+            trace_path(a, i)
+        log_trace(a)
 
-      
+   
 if __name__ == '__main__':
-  m = string.split(sys.argv[1], '.')[0]
-  mtrace(m)
-  # pprint.pprint(mtable)
-  trace_path([], m)
-  kl = 0
-  for k in rm_table.keys():
-    if len(k) > kl:
-      kl = len(k)
+    m = string.split(sys.argv[1], '.')[0]
+    mtrace(m)
+    # pprint.pprint(mtable)
+    trace_path([], m)
+    kl = 0
+    for k in rm_table.keys():
+        if len(k) > kl:
+            kl = len(k)
 
-  output = rm_table.values()
-  output.sort()
-  for i in output:
-    cs = '%-'+`kl`+'s :'
-    print cs%(i[-1]),
-    for j in i[:-1]:
-      print j, '->',
-    print i[-1]
+    output = rm_table.values()
+    output.sort()
+    for i in output:
+        cs = '%-'+`kl`+'s :'
+        print cs%(i[-1]),
+        for j in i[:-1]:
+            print j, '->',
+        print i[-1]

--- a/src/module_trace.py
+++ b/src/module_trace.py
@@ -9,101 +9,118 @@ mtable = {}
 rm_table = {}
 
 def get_module_file(m):
-	for i in sys.path:
-		p = os.path.join(i, m+'.py')
-		if os.access(p, os.R_OK):
-			return p
-		p = os.path.join(i, m+'.so')
-		if os.access(p, os.R_OK):
-			return p
-		p = os.path.join(i, m+'module.c')
-		if os.access(p, os.R_OK):
-			return p
-	return None
+  """Takes module name, returns path to the implementation file."""
+  for i in sys.path:
+    p = os.path.join(i, m+'.py')
+    if os.access(p, os.R_OK):
+      return p
+    p = os.path.join(i, m+'.so')
+    if os.access(p, os.R_OK):
+      return p
+    p = os.path.join(i, m+'module.c')
+    if os.access(p, os.R_OK):
+      return p
+  return None
 
 def mtrace(m):
-	if mtable.has_key(m):
-		return
-	mtable[m] = []
-	mf = get_module_file(m)
-	if mf == None:
-		return
-	f = open(mf)
-	l = f.readline()
-	while l:
-		idx = string.find(l, '"""')
-		if idx != -1 and idx == string.rfind(l, '"""'):
-			l = f.readline()
-			while l and string.find(l, '"""') == -1:
-				l = f.readline()
-		if not l:
-			break
-		l = string.strip(l)
-		l = string.replace(l, ',', ' ')
-		token = string.split(l)
-		tl = len(token)
-		i = 0
-		while i < tl:
-			if token[i][0] == '#': # comment
-				break
-			if (token[i] == 'from' or token[i] == '"from') \
-				and i +2 < tl and token[i+2] == 'import':
-				module = token[i+1]
-				if not module in mtable[m]:
-					mtable[m].append(module)
-				mtrace(module)
-				i = i + 2
-			elif token[i] == 'import':
-				for j in token[i+1:]:
-					if j[0] == '#': # comment
-						break
-					module = j
-					if module[-1] == ',':
-						module = module[:-1]
-					if not module in mtable[m]:
-						mtable[m].append(module)
-					mtrace(module)
-					i = i + 1
-			i = i + 1
-		l = f.readline()
+  """Takes module name, adds imported modules recursively to mtable."""
+  if mtable.has_key(m):
+    return
+  mtable[m] = []
+  mf = get_module_file(m)
+  if mf == None:
+    return
+  f = open(mf)
+  l = f.readline()
+  while l:
+    # Skipping doc strings at beginning of file
+    idx = string.find(l, '"""')
+    if idx != -1 and idx == string.rfind(l, '"""'):
+      l = f.readline()
+      while l and string.find(l, '"""') == -1:
+        l = f.readline()
+    # If there are no more lines, exit
+    if not l:
+      break
+    # Sanitize line and split into tokens
+    l = string.strip(l)
+    l = string.replace(l, ',', ' ')
+    token = string.split(l)
+    tl = len(token)
+    i = 0
+    # Iterate over tokens
+    while i < tl:
+      # Skip to next line if we hit a commnet
+      if token[i][0] == '#': # comment
+        break
+      # If line is `from <mod> import *`
+      if (token[i] == 'from' or token[i] == '"from') \
+        and i +2 < tl and token[i+2] == 'import':
+        module = token[i+1]
+        # Add mod to mtable and recurse
+        if not module in mtable[m]:
+          mtable[m].append(module)
+        mtrace(module)
+        # Move past 'from <mod>'
+        i = i + 2
+      # If line is `import <mod>[,<mod>]*`
+      elif token[i] == 'import':
+        # Iterate over further tokens
+        for j in token[i+1:]:
+          # Exit if we hit a commnet
+          if j[0] == '#': # comment
+            break
+          module = j
+          if module[-1] == ',':
+            module = module[:-1]
+          # Add mod to mtable and recurse
+          if not module in mtable[m]:
+            mtable[m].append(module)
+          mtrace(module)
+          # Move to next mod
+          i = i + 1
+      # Go to next token
+      i = i + 1
+    # Go to next line
+    l = f.readline()
 
 counter = 0
 
 def log_trace(t):
-	if not rm_table.has_key(t[-1]) or len(t) < len(rm_table[t[-1]]):
-			rm_table[t[-1]] = t
+  if not rm_table.has_key(t[-1]) or len(t) < len(rm_table[t[-1]]):
+      rm_table[t[-1]] = t
 def trace_path(history, module):
-	global counter
-	counter = counter + 1
-	# print counter, `history`, module
-	# if counter > 100:
-	#	return
-	if module in history:
-		log_trace(history+[module])
-		return
+  global counter
+  counter = counter + 1
+  # print counter, `history`, module
+  # if counter > 100:
+  #  return
+  if module in history:
+    log_trace(history+[module])
+    return
 
-	if mtable.has_key(module):
-		a = history + [module]
-		for i in mtable[module]:
-			trace_path(a, i)
-		log_trace(a)
+  if mtable.has_key(module):
+    a = history + [module]
+    for i in mtable[module]:
+      trace_path(a, i)
+    log_trace(a)
 
-			
+      
 if __name__ == '__main__':
-	m = string.split(sys.argv[1], '.')[0]
-	mtrace(m)
-	# pprint.pprint(mtable)
-	trace_path([], m)
-	kl = 0
-	for k in rm_table.keys():
-		if len(k) > kl:
-			kl = len(k)
+  m = string.split(sys.argv[1], '.')[0]
+  mtrace(m)
+  # pprint.pprint(mtable)
+  trace_path([], m)
+  kl = 0
+  for k in rm_table.keys():
+    if len(k) > kl:
+      kl = len(k)
 
-	output = rm_table.values()
-	output.sort()
-	for i in output:
-		cs = '%-'+`kl`+'s :'
-		print cs%(i[-1]),
-		for j in i[:-1]:
-			print j, '->',
-		print i[-1]
+  output = rm_table.values()
+  output.sort()
+  for i in output:
+    cs = '%-'+`kl`+'s :'
+    print cs%(i[-1]),
+    for j in i[:-1]:
+      print j, '->',
+    print i[-1]

--- a/src/module_trace.py
+++ b/src/module_trace.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python 
+"""Executable. Given module, prints all imported modules and import chains."""
 import sys
 import string
 import pprint
@@ -87,9 +88,21 @@ def mtrace(m):
 counter = 0
 
 def log_trace(t):
+  """Stores the impot path (t) to a module (t[-1]) rm_table[t[-1]]"""
   if not rm_table.has_key(t[-1]) or len(t) < len(rm_table[t[-1]]):
       rm_table[t[-1]] = t
+
 def trace_path(history, module):
+  """Explore module tree imported by a module.
+
+  Given a module, explores the module tree imported by that module according to mtable, and adds the route to each module to rm_table.
+  
+  Args:
+  module: The name of the module who's import tree should be explored.
+    This module should already be in mtable.
+  history: Set of modules which should be included 'above' the module passed,
+    i.a. its ancestors.
+  """
   global counter
   counter = counter + 1
   # print counter, `history`, module

--- a/src/tests/test_module_trace.py
+++ b/src/tests/test_module_trace.py
@@ -1,0 +1,34 @@
+# movcmd_mc includes C module imports.
+# If this import fails, please read enstore-pytest-c-module.md,
+# and remember to use `python -m pytest`.
+import module_trace
+import os
+import pytest
+from mock import patch
+from module_trace import *
+
+TEST_MODULES = {
+  "tm1": """import tm2\n"""
+         """from tm3 import *""",
+  "tm2": """            """
+         """import tm1\n""",
+  "tm3": """import tm2, tm4""",
+  "tm4": '"""Docstrings"""',
+}
+
+FINAL_MTABLE = {
+  "tm1": ["tm2", "tm3"],
+  "tm2": ["tm1"],
+  "tm3": ["tm2", "tm3"],
+  "tm4": [],
+}
+
+
+def test_get_module_file():
+  assert True # This is just a filepath concatenation.
+
+def test_mtrace(fs):
+  module_trace.mtrace("test_mod1")
+  fs.create_file("tm1")
+  assert True
+

--- a/src/tests/test_module_trace.py
+++ b/src/tests/test_module_trace.py
@@ -9,64 +9,65 @@ from mock import patch
 from module_trace import *
 
 TEST_MODULES = {
-  'tm1': """import tm2\n"""
-         """from tm3 import *""",
-  'tm2': """            \n"""
-         """import tm1\n # comment"""
-         """bonus lines""",
-  'tm3': """import tm2, tm4""",
-  'tm4': '"""Docstrings"""',
+    'tm1': """import tm2\n"""
+           """from tm3 import *""",
+    'tm2': """            \n"""
+           """import tm1\n # comment"""
+           """bonus lines""",
+    'tm3': """import tm2, tm4""",
+    'tm4': '"""Docstrings"""',
 }
 
 # Import tree starting at 'tm1'
 FINAL_MTABLE = {
-  'tm1': ['tm2', 'tm3'],
-  'tm2': ['tm1'],
-  'tm3': ['tm2', 'tm4'],
-  'tm4': [],
+    'tm1': ['tm2', 'tm3'],
+    'tm2': ['tm1'],
+    'tm3': ['tm2', 'tm4'],
+    'tm4': [],
 }
 
 # Route to import, by module, starting at 'tm1'
 FINAL_RM_TABLE = {
- 'tm1': ['tm1'],
- 'tm2': ['tm1', 'tm2'],
- 'tm3': ['tm1', 'tm3'],
- 'tm4': ['tm1', 'tm3', 'tm4'],
+   'tm1': ['tm1'],
+   'tm2': ['tm1', 'tm2'],
+   'tm3': ['tm1', 'tm3'],
+   'tm4': ['tm1', 'tm3', 'tm4'],
 }
 
 def _setup_fake_fs(fake_fs):
-  for (filename, data) in TEST_MODULES.items():
-    fake_fs.create_file(filename, contents=data)
+    for (filename, data) in TEST_MODULES.items():
+        fake_fs.create_file(filename, contents=data)
 
 def _fake_get_module_file(m):
-  return m
+    return m
 
 def test_get_module_file():
-  assert True # This is just a filepath concatenation.
+    assert True # This is just a filepath concatenation.
 
 def test_mtrace(fs):
-  _setup_fake_fs(fs)
-  with patch("module_trace.get_module_file", wraps=_fake_get_module_file) as _:
-    mtrace("tm1")
-    assert(module_trace.mtable == FINAL_MTABLE)
-    module_trace.mtable = {}
+    _setup_fake_fs(fs)
+    with patch("module_trace.get_module_file",
+               wraps=_fake_get_module_file) as _:
+        mtrace("tm1")
+        assert(module_trace.mtable == FINAL_MTABLE)
+        module_trace.mtable = {}
 
 def test_log_trace(fs):
-  path = ["a", "s", "d"]
-  log_trace(path)
-  assert module_trace.rm_table == {"d": path}
-  module_trace.rm_table = {}
+    path = ["a", "s", "d"]
+    log_trace(path)
+    assert module_trace.rm_table == {"d": path}
+    module_trace.rm_table = {}
 
 def test_trace_path(fs):
-  _setup_fake_fs(fs)
-  with patch("module_trace.get_module_file", wraps=_fake_get_module_file) as _:
-    module_trace.trace_path([], "tm1")
-    assert(module_trace.rm_table == {})
-    mtrace("tm1")
-    module_trace.trace_path([], "tm1")
-    assert(module_trace.rm_table == FINAL_RM_TABLE)
-    module_trace.trace_path([], "module_not_found")
-    assert(module_trace.rm_table == FINAL_RM_TABLE)
-    module_trace.mtable = {}
-    module_trace.rm_table = {}
-  
+    _setup_fake_fs(fs)
+    with patch("module_trace.get_module_file", wraps=_fake_get_module_file) as _:
+        module_trace.trace_path([], "tm1")
+        assert(module_trace.rm_table == {})
+        mtrace("tm1")
+        module_trace.trace_path([], "tm1")
+        assert(module_trace.rm_table == FINAL_RM_TABLE)
+        module_trace.trace_path([], "module_not_found")
+        assert(module_trace.rm_table == FINAL_RM_TABLE)
+        module_trace.mtable = {}
+        module_trace.rm_table = {}
+

--- a/src/tests/test_module_trace.py
+++ b/src/tests/test_module_trace.py
@@ -2,33 +2,71 @@
 # If this import fails, please read enstore-pytest-c-module.md,
 # and remember to use `python -m pytest`.
 import module_trace
+import pprint
 import os
 import pytest
 from mock import patch
 from module_trace import *
 
 TEST_MODULES = {
-  "tm1": """import tm2\n"""
+  'tm1': """import tm2\n"""
          """from tm3 import *""",
-  "tm2": """            """
-         """import tm1\n""",
-  "tm3": """import tm2, tm4""",
-  "tm4": '"""Docstrings"""',
+  'tm2': """            \n"""
+         """import tm1\n # comment"""
+         """bonus lines""",
+  'tm3': """import tm2, tm4""",
+  'tm4': '"""Docstrings"""',
 }
 
+# Import tree starting at 'tm1'
 FINAL_MTABLE = {
-  "tm1": ["tm2", "tm3"],
-  "tm2": ["tm1"],
-  "tm3": ["tm2", "tm3"],
-  "tm4": [],
+  'tm1': ['tm2', 'tm3'],
+  'tm2': ['tm1'],
+  'tm3': ['tm2', 'tm4'],
+  'tm4': [],
 }
 
+# Route to import, by module, starting at 'tm1'
+FINAL_RM_TABLE = {
+ 'tm1': ['tm1'],
+ 'tm2': ['tm1', 'tm2'],
+ 'tm3': ['tm1', 'tm3'],
+ 'tm4': ['tm1', 'tm3', 'tm4'],
+}
+
+def _setup_fake_fs(fake_fs):
+  for (filename, data) in TEST_MODULES.items():
+    fake_fs.create_file(filename, contents=data)
+
+def _fake_get_module_file(m):
+  return m
 
 def test_get_module_file():
   assert True # This is just a filepath concatenation.
 
 def test_mtrace(fs):
-  module_trace.mtrace("test_mod1")
-  fs.create_file("tm1")
-  assert True
+  _setup_fake_fs(fs)
+  with patch("module_trace.get_module_file", wraps=_fake_get_module_file) as _:
+    mtrace("tm1")
+    assert(module_trace.mtable == FINAL_MTABLE)
+    module_trace.mtable = {}
 
+def test_log_trace(fs):
+  path = ["a", "s", "d"]
+  log_trace(path)
+  assert module_trace.rm_table == {"d": path}
+  module_trace.rm_table = {}
+
+def test_trace_path(fs):
+  _setup_fake_fs(fs)
+  with patch("module_trace.get_module_file", wraps=_fake_get_module_file) as _:
+    module_trace.trace_path([], "tm1")
+    assert(module_trace.rm_table == {})
+    mtrace("tm1")
+    module_trace.trace_path([], "tm1")
+    assert(module_trace.rm_table == FINAL_RM_TABLE)
+    module_trace.trace_path([], "module_not_found")
+    assert(module_trace.rm_table == FINAL_RM_TABLE)
+    module_trace.mtable = {}
+    module_trace.rm_table = {}
+  

--- a/src/tests/test_movcmd_mc.py
+++ b/src/tests/test_movcmd_mc.py
@@ -1,3 +1,6 @@
+# movcmd_mc includes C module imports.
+# If this import fails, please read enstore-pytest-c-module.md,
+# and remember to use `python -m pytest`.
 import movcmd_mc
 import os
 import pytest

--- a/src/tests/test_movcmd_mc.py
+++ b/src/tests/test_movcmd_mc.py
@@ -1,9 +1,9 @@
-import unittest
-import pytest
-import os
 import movcmd_mc
-from movcmd_mc import *
+import os
+import pytest
+import unittest
 from mock import patch
+from movcmd_mc import *
 
 TESTCONFIG = {
   'enstor01.mover': {

--- a/src/tests/test_movcmd_mc.py
+++ b/src/tests/test_movcmd_mc.py
@@ -8,56 +8,56 @@ from mock import patch
 from movcmd_mc import *
 
 TESTCONFIG = {
-  'enstor01.mover': {
-     'media_changer': 'enstor06.media_changer',
-  },
-  'enstor02.mover': {},
-  'enstor03.library': {'asd': '1'},
-  'enstor04.pagg': {
-    '127.9.1': ['asd'],
-    '127.3.55a': ['2g'],
-  },
+    'enstor01.mover': {
+         'media_changer': 'enstor06.media_changer',
+    },
+    'enstor02.mover': {},
+    'enstor03.library': {'asd': '1'},
+    'enstor04.pagg': {
+        '127.9.1': ['asd'],
+        '127.3.55a': ['2g'],
+    },
 }
 
 def test_endswith():
-  assert endswith("asd", "sd")
-  assert not endswith("asd", "fd")
+    assert endswith("asd", "sd")
+    assert not endswith("asd", "fd")
 
 def test_dict_eval():
-  with pytest.raises(ValueError):
-    dict_eval("notadict")
-  assert dict_eval("{thisdictisjunk}") == {}
-  test_value = "{'thisdict': 'is ok'}_even_with_junk"
-  test_response = {"thisdict": "is ok"}
-  assert dict_eval(test_value) == test_response
+    with pytest.raises(ValueError):
+        dict_eval("notadict")
+    assert dict_eval("{thisdictisjunk}") == {}
+    test_value = "{'thisdict': 'is ok'}_even_with_junk"
+    test_response = {"thisdict": "is ok"}
+    assert dict_eval(test_value) == test_response
 
 def test_get_config():
-  expected_res = {'movers': ['enmv1', 'enmv2'], 'host': 'enconf1'}
-  test_read_data = "%s" % expected_res
-  with patch.object(os, 'popen') as mock_popen:
-    mock_popen().read.return_value = test_read_data
-    assert get_config() == expected_res
+    expected_res = {'movers': ['enmv1', 'enmv2'], 'host': 'enconf1'}
+    test_read_data = "%s" % expected_res
+    with patch.object(os, 'popen') as mock_popen:
+        mock_popen().read.return_value = test_read_data
+        assert get_config() == expected_res
 
 def test_get_movers():
-  expected_res = ['enstor01', 'enstor02']
-  assert get_movers(config=TESTCONFIG) == expected_res
-  with patch.object(movcmd_mc, 'get_config') as mock_get_config:
-    mock_get_config.return_value = TESTCONFIG
-    assert get_movers() == expected_res
+    expected_res = ['enstor01', 'enstor02']
+    assert get_movers(config=TESTCONFIG) == expected_res
+    with patch.object(movcmd_mc, 'get_config') as mock_get_config:
+        mock_get_config.return_value = TESTCONFIG
+        assert get_movers() == expected_res
 
 def test_get_media_changer():
-  get_media_changer_res = get_media_changer(
+    get_media_changer_res = get_media_changer(
       'enstor01.mover', config=TESTCONFIG)
-  assert get_media_changer_res == 'enstor06'
-  with patch.object(movcmd_mc, 'get_config') as mock_get_config:
-    mock_get_config.return_value = TESTCONFIG
-    get_media_changer_res = get_media_changer('enstor01.mover')
     assert get_media_changer_res == 'enstor06'
-    get_media_changer_res = get_media_changer('enstor01')
-    assert get_media_changer_res == 'NotFound'
+    with patch.object(movcmd_mc, 'get_config') as mock_get_config:
+        mock_get_config.return_value = TESTCONFIG
+        get_media_changer_res = get_media_changer('enstor01.mover')
+        assert get_media_changer_res == 'enstor06'
+        get_media_changer_res = get_media_changer('enstor01')
+        assert get_media_changer_res == 'NotFound'
 
 def test_mc_for_movers():
-  expected_res = {'Unknown': ['enstor02'], 'enstor06': ['enstor01']}
-  with patch.object(movcmd_mc, 'get_config') as mock_get_config:
-    mock_get_config.return_value = TESTCONFIG
-    assert mc_for_movers() == expected_res
+    expected_res = {'Unknown': ['enstor02'], 'enstor06': ['enstor01']}
+    with patch.object(movcmd_mc, 'get_config') as mock_get_config:
+        mock_get_config.return_value = TESTCONFIG
+        assert mc_for_movers() == expected_res

--- a/src/tests/test_movcmd_mc.py
+++ b/src/tests/test_movcmd_mc.py
@@ -1,0 +1,67 @@
+import unittest
+import pytest
+import os
+import movcmd_mc
+from movcmd_mc import *
+from mock import patch
+
+TESTCONFIG = {
+  'enstor01.mover': {
+     'media_changer': 'enstor06.media_changer',
+  },
+  'enstor02.mover': {},
+  'enstor03.library': {'asd': '1'},
+  'enstor04.pagg': {
+    '127.9.1': ['asd'],
+    '127.3.55a': ['2g'],
+  },
+}
+
+class TestMovcmdMc(unittest.TestCase):
+
+    def test_endswith(self):
+      assert endswith("asd", "sd")
+      assert not endswith("asd", "fd")
+
+    def test_dict_eval(self):
+      with pytest.raises(ValueError):
+        dict_eval("notadict")
+      assert dict_eval("{thisdictisjunk}") == {}
+      test_value = "{'thisdict': 'is ok'}_even_with_junk"
+      test_response = {"thisdict": "is ok"}
+      assert dict_eval(test_value) == test_response
+
+    def test_get_config(self):
+      expected_res = {'movers': ['enmv1', 'enmv2'], 'host': 'enconf1'}
+      test_read_data = "%s" % expected_res
+      with patch.object(os, 'popen') as mock_popen:
+        mock_popen().read.return_value = test_read_data
+        assert get_config() == expected_res
+
+    def test_get_movers(self):
+      expected_res = ['enstor01', 'enstor02']
+      assert get_movers(config=TESTCONFIG) == expected_res
+      with patch.object(movcmd_mc, 'get_config') as mock_get_config:
+        mock_get_config.return_value = TESTCONFIG
+        assert get_movers() == expected_res
+
+    def test_get_media_changer(self):
+      get_media_changer_res = get_media_changer(
+          'enstor01.mover', config=TESTCONFIG)
+      assert get_media_changer_res == 'enstor06'
+      with patch.object(movcmd_mc, 'get_config') as mock_get_config:
+        mock_get_config.return_value = TESTCONFIG
+        get_media_changer_res = get_media_changer('enstor01.mover')
+        assert get_media_changer_res == 'enstor06'
+        get_media_changer_res = get_media_changer('enstor01')
+        assert get_media_changer_res == 'NotFound'
+
+    def test_mc_for_movers(self):
+      expected_res = {'Unknown': ['enstor02'], 'enstor06': ['enstor01']}
+      with patch.object(movcmd_mc, 'get_config') as mock_get_config:
+        mock_get_config.return_value = TESTCONFIG
+        assert mc_for_movers() == expected_res
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_movcmd_mc.py
+++ b/src/tests/test_movcmd_mc.py
@@ -4,7 +4,6 @@
 import movcmd_mc
 import os
 import pytest
-import unittest
 from mock import patch
 from movcmd_mc import *
 
@@ -20,51 +19,45 @@ TESTCONFIG = {
   },
 }
 
-class TestMovcmdMc(unittest.TestCase):
+def test_endswith():
+  assert endswith("asd", "sd")
+  assert not endswith("asd", "fd")
 
-    def test_endswith(self):
-      assert endswith("asd", "sd")
-      assert not endswith("asd", "fd")
+def test_dict_eval():
+  with pytest.raises(ValueError):
+    dict_eval("notadict")
+  assert dict_eval("{thisdictisjunk}") == {}
+  test_value = "{'thisdict': 'is ok'}_even_with_junk"
+  test_response = {"thisdict": "is ok"}
+  assert dict_eval(test_value) == test_response
 
-    def test_dict_eval(self):
-      with pytest.raises(ValueError):
-        dict_eval("notadict")
-      assert dict_eval("{thisdictisjunk}") == {}
-      test_value = "{'thisdict': 'is ok'}_even_with_junk"
-      test_response = {"thisdict": "is ok"}
-      assert dict_eval(test_value) == test_response
+def test_get_config():
+  expected_res = {'movers': ['enmv1', 'enmv2'], 'host': 'enconf1'}
+  test_read_data = "%s" % expected_res
+  with patch.object(os, 'popen') as mock_popen:
+    mock_popen().read.return_value = test_read_data
+    assert get_config() == expected_res
 
-    def test_get_config(self):
-      expected_res = {'movers': ['enmv1', 'enmv2'], 'host': 'enconf1'}
-      test_read_data = "%s" % expected_res
-      with patch.object(os, 'popen') as mock_popen:
-        mock_popen().read.return_value = test_read_data
-        assert get_config() == expected_res
+def test_get_movers():
+  expected_res = ['enstor01', 'enstor02']
+  assert get_movers(config=TESTCONFIG) == expected_res
+  with patch.object(movcmd_mc, 'get_config') as mock_get_config:
+    mock_get_config.return_value = TESTCONFIG
+    assert get_movers() == expected_res
 
-    def test_get_movers(self):
-      expected_res = ['enstor01', 'enstor02']
-      assert get_movers(config=TESTCONFIG) == expected_res
-      with patch.object(movcmd_mc, 'get_config') as mock_get_config:
-        mock_get_config.return_value = TESTCONFIG
-        assert get_movers() == expected_res
+def test_get_media_changer():
+  get_media_changer_res = get_media_changer(
+      'enstor01.mover', config=TESTCONFIG)
+  assert get_media_changer_res == 'enstor06'
+  with patch.object(movcmd_mc, 'get_config') as mock_get_config:
+    mock_get_config.return_value = TESTCONFIG
+    get_media_changer_res = get_media_changer('enstor01.mover')
+    assert get_media_changer_res == 'enstor06'
+    get_media_changer_res = get_media_changer('enstor01')
+    assert get_media_changer_res == 'NotFound'
 
-    def test_get_media_changer(self):
-      get_media_changer_res = get_media_changer(
-          'enstor01.mover', config=TESTCONFIG)
-      assert get_media_changer_res == 'enstor06'
-      with patch.object(movcmd_mc, 'get_config') as mock_get_config:
-        mock_get_config.return_value = TESTCONFIG
-        get_media_changer_res = get_media_changer('enstor01.mover')
-        assert get_media_changer_res == 'enstor06'
-        get_media_changer_res = get_media_changer('enstor01')
-        assert get_media_changer_res == 'NotFound'
-
-    def test_mc_for_movers(self):
-      expected_res = {'Unknown': ['enstor02'], 'enstor06': ['enstor01']}
-      with patch.object(movcmd_mc, 'get_config') as mock_get_config:
-        mock_get_config.return_value = TESTCONFIG
-        assert mc_for_movers() == expected_res
-
-
-if __name__ == "__main__":
-    unittest.main()
+def test_mc_for_movers():
+  expected_res = {'Unknown': ['enstor02'], 'enstor06': ['enstor01']}
+  with patch.object(movcmd_mc, 'get_config') as mock_get_config:
+    mock_get_config.return_value = TESTCONFIG
+    assert mc_for_movers() == expected_res


### PR DESCRIPTION
Add tests for movcmd_mc and module_trace. I've chosen these by sorting the python files by line count and working up from 100, just to start building familiarity.

NOTE: These tests import C modules, which means invoking them via pytest will fail with importErrors unless Python is configured as described in https://github.com/Enstore-org/enstore/blob/develop/src/tests/enstore-pytest-c-module.md