### PR TITLE
Enmvr045 config chooser

### DIFF
--- a/rpm_version
+++ b/rpm_version
@@ -1,6 +1,6 @@
 EVersion=6.3.4
 ERelease=16
-ECommit=15
+ECommit=16
 export EVersion
 export ERelease
 export ECommit

--- a/rpm_version
+++ b/rpm_version
@@ -1,6 +1,6 @@
 EVersion=6.3.4
 ERelease=16
-ECommit=14
+ECommit=15
 export EVersion
 export ERelease
 export ECommit

--- a/ups/chooseConfig
+++ b/ups/chooseConfig
@@ -117,7 +117,7 @@ case $node in
 	    ENSTORE_CONFIG_FILE=sam.conf
 	    qualifier=d0en
 	    ;;
-
+  # TODO(renbauer) I think gccen machines are all dmsen hosts now
   gccen*)   ENSTORE_MAIL=moibenko@fnal.gov,litvinse@fnal.gov,renbauer@fnal.gov
 	    ENSTORE_CONFIG_HOST=$gccen
 	    ENSTORE_CONFIG_FILE=gccen.conf

--- a/ups/chooseConfig
+++ b/ups/chooseConfig
@@ -71,6 +71,8 @@ get_logname()
 ENSTORE_MAIL=enstore-auto@fnal.gov
 if [ `get_logname`x = 'dcache'x ]; then ENSTORE_MAIL=dcache-auto@fnal.gov; fi
 
+# TODO(renbauer): maintain this elsewhere or
+# check enstore-config instead of duplicating here
 case $node in
 
   stkenscan*)
@@ -116,16 +118,21 @@ case $node in
 	    qualifier=d0en
 	    ;;
 
-  gccen*)   ENSTORE_MAIL=moibenko@fnal.gov,litvinse@fnal.gov
+  gccen*)   ENSTORE_MAIL=moibenko@fnal.gov,litvinse@fnal.gov,renbauer@fnal.gov
 	    ENSTORE_CONFIG_HOST=$gccen
 	    ENSTORE_CONFIG_FILE=gccen.conf
 	    complain=0
 	    ;;
-  dmsen*)   ENSTORE_MAIL=moibenko@fnal.gov,litvinse@fnal.gov
+  dmsen*)   ENSTORE_MAIL=moibenko@fnal.gov,litvinse@fnal.gov,renbauer@fnal.gov
 	    ENSTORE_CONFIG_HOST=$dmsen
 	    ENSTORE_CONFIG_FILE=dmsen.conf
 	    complain=0
 	    ;;
+  enmvr045) ENSTORE_MAIL=moibenko@fnal.gov,litvinse@fnal.gov,renbauer@fnal.gov
+            ENSTORE_CONFIG_HOST=$dmsen
+            ENSTORE_CONFIG_FILE=dmsen.conf
+            complain=0
+            ;;
 
   *)    ENSTORE_CONFIG_HOST=$stken
 	    ENSTORE_CONFIG_FILE=stk.conf


### PR DESCRIPTION
Add enmvr045 as a dmsen host to config choose script.

All this information should be available from the enstore-config repo, we should work to avoid duplicating it here.