### PR TITLE
egnore "noread" LM state

### DIFF
--- a/src/encp.py
+++ b/src/encp.py
@@ -2521,6 +2521,9 @@ def check_library(library, e):
         #                               "%s is ignoring requests." % lib)
         #if state == "pause":
         #    status_ticket['status'] = (e_errors.PAUSE,
+        if state == "noread" and e.check:
+            # ignore LM state
+            status_ticket['status'] = (e_errors.OK, None)
         #                               "%s is paused." % lib)
         if state == "noread" and is_read(e):
             status_ticket['status'] = (e_errors.NOREAD,

--- a/src/encp.py
+++ b/src/encp.py
@@ -2516,18 +2516,14 @@ def check_library(library, e):
         if state == "locked":
             status_ticket['status'] = (e_errors.LOCKED,
                                        "%s is locked." % lib)
-        #if state == "ignore":
-        #    status_ticket['status'] = (e_errors.IGNORE,
-        #                               "%s is ignoring requests." % lib)
-        #if state == "pause":
-        #    status_ticket['status'] = (e_errors.PAUSE,
-        if state == "noread" and e.check:
-            # ignore LM state
-            status_ticket['status'] = (e_errors.OK, None)
-        #                               "%s is paused." % lib)
+
         if state == "noread" and is_read(e):
-            status_ticket['status'] = (e_errors.NOREAD,
-                                    "%s is ignoring read requests." % lib)
+            if e.check:
+                # ignore LM state
+                status_ticket['status'] = (e_errors.OK, None)
+            else:
+                status_ticket['status'] = (e_errors.NOREAD,
+                                           "%s is ignoring read requests." % lib)
         if state == "nowrite" and is_write(e):
             status_ticket['status'] = (e_errors.NOWRITE,
                                     "%s is ignoring write requests." % lib)


### PR DESCRIPTION
This fix addresses the error seen in migration:

```
error = ('noread', 'CD-DiskSF3.library_manager is ignoring read requests.') ...
```