### PR TITLE
Manage queue unit tests

### DIFF
--- a/release-notes/enstore-nonprod-6.3.4-17.8.txt
+++ b/release-notes/enstore-nonprod-6.3.4-17.8.txt
@@ -1,5 +1,124 @@
+commit 1f1ebf70c1821de2862e3150ce28c1f7629a4c4b
+Author: Ren Bauer <renbauer@fnal.gov>
+Date:   Tue Nov 1 23:13:02 2022 +0000
+
+    Update manage_queue data structures to sets from lists. These are only used for presence checking which is much faster in sets.
+    
+    In testing (with only read calls), this change constitutes a speedup of about 2% for the LM.
+
+commit ae14baf0a8d0ba5a5e1870ef8ef503e6d416ad81
+Author: Ren Bauer <renbauer@fnal.gov>
+Date:   Tue Nov 1 16:59:50 2022 +0000
+
+    Delete unused run_in_thread methods
+
 commit d9a67c7fc63dd91e2b1f878d7e94745adb9ab089
 Author: Ren Bauer <renbauer@fnal.gov>
 Date:   Thu Oct 27 17:05:03 2022 +0000
 
     Fix typo in if statement
+
+commit 8b321ab346b2ae005eb8f458e08a5b3509250cdb
+Author: Ren Bauer <renbauer@fnal.gov>
+Date:   Fri Oct 14 21:15:27 2022 +0000
+
+    Comment out broken import
+
+commit f14caad5780793b9a30564e539b57a0b3b3db53d
+Author: Ren Bauer <renbauer@fnal.gov>
+Date:   Fri Sep 23 19:54:31 2022 +0000
+
+    Fix library_manager logic so 'override_notallowed' overrides only NOTALLOWED and not also NOACCESS
+    
+    Searching the source, it doesn't appear 'override_notallowed' is used by any process other than manual migration, so this change should be low risk.
+
+commit b00a8d7a5957072098849e3aa071b0b77ce83de5
+Author: Ren Bauer <renbauer@fnal.gov>
+Date:   Fri Sep 23 19:48:49 2022 +0000
+
+    Override NOTALLOWED inhibit in assert requests from volume_assert.
+    
+    This error is coming from https://github.com/Enstore-org/enstore/blob/develop/src/library_manager.py#L4015, which can be skipped by setting override_notallowed on the ticket.
+    
+    Note this will also cause volume_assert requests to work on NOACCESS volumes, which I believe is unintended. This will be resolved in a follow-up commit.
+
+commit 0ffc99d2d7cd16779fda59f43d622f5633b20c43
+Author: Dmitry Litvintsev <litvinse@fnal.gov>
+Date:   Thu Aug 18 14:05:05 2022 -0500
+
+    add LTO9 constants
+
+commit 22912f6af4a9d69df73885d6035ba50e75bbda56
+Author: Ren Bauer <renbauer@fnal.gov>
+Date:   Tue Aug 2 19:38:45 2022 +0000
+
+    Fix except syntax
+
+commit 8eefaf77349eb4b9e058e8026fb5838be2d7a358
+Author: Ren Bauer <renbauer@fnal.gov>
+Date:   Tue Aug 2 19:32:14 2022 +0000
+
+    Add sanity_crc to default mover.Buffer
+
+commit 124dd815cd4cac0e1f9d0b1b352155cead07e92d
+Author: Ren Bauer <renbauer@fnal.gov>
+Date:   Tue Aug 2 19:25:57 2022 +0000
+
+    Update mover.create_instance to support classes with no construction params
+
+commit 094297c63f32cb5f19edaf21945ef56eedbadc3b
+Merge: d469d27db efe18e9cf
+Author: renbauer-fnal <89218226+renbauer-fnal@users.noreply.github.com>
+Date:   Thu Jul 28 11:59:41 2022 -0400
+
+    Merge pull request #90 from dbox-fnal/test_generic_client.py
+    
+    unit test for generic_client.py
+
+commit adc9758042aab72ccad3734f01dff3c6efc15024
+Author: Dmitry Litvintsev <litvinse@fnal.gov>
+Date:   Wed Jul 27 17:18:32 2022 -0500
+
+    address Ren's comment`
+
+commit 19b93d73a81017729d75fe04b81fee09e4f64a87
+Author: Dmitry Litvintsev <litvinse@fnal.gov>
+Date:   Wed Jul 27 17:15:15 2022 -0500
+
+    address Ren's comment
+
+commit 13a27acc24419a2b5bd00d35360fb03c9f81e106
+Author: Dmitry Litvintsev <litvinse@fnal.gov>
+Date:   Wed Jul 27 14:27:39 2022 -0500
+
+    fix typo
+
+commit 53253525521cd6cc98a4e28882f900363d7d64a9
+Author: Dmitry Litvintsev <litvinse@fnal.gov>
+Date:   Wed Jul 27 14:23:59 2022 -0500
+
+    Fix to resolve BZ2589
+
+commit efe18e9cf633f7ab0e813bda6f78d1302353cae2
+Author: Dennis Box <dbox@fnal.gov>
+Date:   Thu Jun 23 15:19:31 2022 -0500
+
+    unit test for generic_client.py
+
+commit 2d637bdf88228374e8bf8a511b0053cba7b056a0
+Author: Ren Bauer <renbauer@fnal.gov>
+Date:   Wed Apr 6 22:01:49 2022 +0000
+
+    Finish enstore_functions tests except run_in_thread
+
+commit 419ea06048bfcca914b742b946fad9e5ec8572ac
+Author: Ren Bauer <renbauer@fnal.gov>
+Date:   Tue Apr 5 22:12:59 2022 +0000
+
+    Start of enstore_functions tests
+
+commit 80ab21051db42daba74b694b298e22654707472a
+Author: Dennis Box <dbox@fnal.gov>
+Date:   Tue May 3 12:22:49 2022 -0500
+
+    deleted RCS macro

--- a/src/tests/test_Trace.py
+++ b/src/tests/test_Trace.py
@@ -16,10 +16,12 @@ import enstore_constants
 import Trace
 from Trace import *
 
-DONT_ALARM_CAPABLE_LIST  = [e_errors.EMAIL, e_errors.ERROR, e_errors.USER_ERROR ]
+DONT_ALARM_CAPABLE_LIST = [e_errors.EMAIL, e_errors.ERROR, e_errors.USER_ERROR]
 # an alarm function to test Trace.py with
+
+
 def alarm_func_0(time, pid, name, root_error,
-		   severity, condition, remedy_type, args):
+                 severity, condition, remedy_type, args):
     """
     Alarm function
 
@@ -45,7 +47,7 @@ def alarm_func_0(time, pid, name, root_error,
     __pychecker__ = "unusednames=time"
 
     # translate severity to text
-    if type(severity) == types.IntType:
+    if isinstance(severity, types.IntType):
         severity = e_errors.sevdict.get(severity,
                                         e_errors.sevdict[e_errors.ERROR])
     ticket = {}
@@ -58,21 +60,24 @@ def alarm_func_0(time, pid, name, root_error,
     ticket[enstore_constants.CONDITION] = condition
     ticket[enstore_constants.REMEDY_TYPE] = remedy_type
     ticket['text'] = args
-    log_msg = "%s, %s (severity : %s)"%(root_error, args, severity)
+    log_msg = "%s, %s (severity : %s)" % (root_error, args, severity)
 
     Trace.log(e_errors.ALARM, log_msg, Trace.MSG_ALARM)
 
 # a log function to test Trace.py with
-def log_func_0 (timestamp, pid, name, args):
-    #Even though this implimentation of log_func() does not use the time
+
+
+def log_func_0(timestamp, pid, name, args):
+    # Even though this implimentation of log_func() does not use the time
     # parameter, others will.
     __pychecker__ = "unusednames=time"
 
     severity = args[0]
     msg = args[1]
-    logmsg = 'log_func_0 %s %.6d %.8s %s %s  %s'%(time.ctime(timestamp), pid, usr, e_errors.sevdict[severity], name, msg)
+    logmsg = 'log_func_0 %s %.6d %.8s %s %s  %s' % (time.ctime(
+        timestamp), pid, usr, e_errors.sevdict[severity], name, msg)
     if severity in Trace.STDERR_SEVERITIES:
-        print >> sys.stderr , logmsg
+        print >> sys.stderr, logmsg
     else:
         print logmsg
     return None
@@ -90,7 +95,7 @@ class TestTrace(unittest.TestCase):
         set_logname('FOO')
         lg = get_logname()
         self.assertEqual(lg, 'FOO')
-    
+
     def test_get_threadname(self):
         tn = get_threadname()
         self.assertEqual(tn, self.threadname)
@@ -107,44 +112,51 @@ class TestTrace(unittest.TestCase):
 
     def test_log_functionality(self):
         msg = 'this is  a log msg'
-        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as std_out:
             log(e_errors.INFO, msg)
-            self.assertTrue( msg in std_out.getvalue(), std_out.getvalue())
+            self.assertTrue(msg in std_out.getvalue(), std_out.getvalue())
         set_log_func(log_func_0)
-        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as std_out:
             log(e_errors.INFO, msg)
-            self.assertTrue( msg in std_out.getvalue(), std_out.getvalue())
-            self.assertTrue( 'log_func_0'  in std_out.getvalue(), std_out.getvalue())
+            self.assertTrue(msg in std_out.getvalue(), std_out.getvalue())
+            self.assertTrue(
+                'log_func_0' in std_out.getvalue(),
+                std_out.getvalue())
 
     def test_log_to_stderr(self):
         msg = 'this is  a log msg'
         for severity in Trace.STDERR_SEVERITIES:
-            with mock.patch('sys.stderr', new = StringIO.StringIO()) as std_err:
+            with mock.patch('sys.stderr', new=StringIO.StringIO()) as std_err:
                 log(severity, msg)
-                self.assertTrue( msg in std_err.getvalue(), std_err.getvalue())
+                self.assertTrue(msg in std_err.getvalue(), std_err.getvalue())
             set_log_func(log_func_0)
-            with mock.patch('sys.stderr', new = StringIO.StringIO()) as std_err:
+            with mock.patch('sys.stderr', new=StringIO.StringIO()) as std_err:
                 log(severity, msg)
-                self.assertTrue( msg in std_err.getvalue(), std_err.getvalue())
-                self.assertTrue( 'log_func_0'  in std_err.getvalue(), std_err.getvalue())
-    
+                self.assertTrue(msg in std_err.getvalue(), std_err.getvalue())
+                self.assertTrue(
+                    'log_func_0' in std_err.getvalue(),
+                    std_err.getvalue())
+
     def test_alarm_functionality(self):
         msg = 'this is  an alarm!!!'
-        #test default alarm function
-        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+        # test default alarm function
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as std_out:
             alarm(e_errors.ALARM, msg)
-            self.assertTrue( 'default_alarm_func'  in std_out.getvalue(), std_out.getvalue())
+            self.assertTrue(
+                'default_alarm_func' in std_out.getvalue(),
+                std_out.getvalue())
 
         # test setting custom alarm
         set_alarm_func(alarm_func_0)
-        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as std_out:
             alarm(e_errors.ALARM, msg)
-            self.assertTrue( msg in std_out.getvalue(), std_out.getvalue())
+            self.assertTrue(msg in std_out.getvalue(), std_out.getvalue())
 
     def test_do_and_dont_print(self):
         self.assertEqual(len(print_levels.keys()), 0)
         do_print(Trace.STDERR_SEVERITIES)
-        self.assertEqual(len(print_levels.keys()), len(Trace.STDERR_SEVERITIES))
+        self.assertEqual(len(print_levels.keys()),
+                         len(Trace.STDERR_SEVERITIES))
         dont_print(Trace.STDERR_SEVERITIES)
         self.assertEqual(len(print_levels.keys()), 0)
 
@@ -155,11 +167,11 @@ class TestTrace(unittest.TestCase):
         dont_log(Trace.STDERR_SEVERITIES)
         self.assertEqual(len(log_levels.keys()), 0)
 
-
     def test_do_and_dont_message(self):
         self.assertEqual(len(message_levels.keys()), 0)
         do_message(Trace.STDERR_SEVERITIES)
-        self.assertEqual(len(message_levels.keys()), len(Trace.STDERR_SEVERITIES))
+        self.assertEqual(len(message_levels.keys()),
+                         len(Trace.STDERR_SEVERITIES))
         try:
             dont_message(Trace.STDERR_SEVERITIES)
             self.assertTrue(False)
@@ -171,7 +183,8 @@ class TestTrace(unittest.TestCase):
     def test_do_and_dont_alarm(self):
         self.assertEqual(len(alarm_levels.keys()), 0)
         do_alarm(Trace.STDERR_SEVERITIES)
-        self.assertEqual(len(alarm_levels.keys()), len(Trace.STDERR_SEVERITIES))
+        self.assertEqual(len(alarm_levels.keys()),
+                         len(Trace.STDERR_SEVERITIES))
         try:
             dont_alarm(Trace.STDERR_SEVERITIES)
             self.assertTrue(False)
@@ -193,44 +206,53 @@ class TestTrace(unittest.TestCase):
         msg += "ous correlation. Oh well."
 
         len1 = len(msg)
-        max_msg_size = set_max_message_size(len1/2)
+        max_msg_size = set_max_message_size(len1 / 2)
         msg2 = trunc(msg)
         len2 = len(msg2)
         self.assertTrue(len2 < len1)
 
-
     def test_trace(self):
-        ticket = {'status':'test'}
+        ticket = {'status': 'test'}
         dont_print(1)
         do_alarm(1)
         do_log(1)
-        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
-            with mock.patch('sys.stderr', new = StringIO.StringIO()) as std_err:
-       	        trace(1, 'a spurious test message: %s' % (ticket,))
-                self.assertTrue('spurious' in std_err.getvalue(), "t2:%s" %(std_err.getvalue()))
-    
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as std_out:
+            with mock.patch('sys.stderr', new=StringIO.StringIO()) as std_err:
+                trace(1, 'a spurious test message: %s' % (ticket,))
+                self.assertTrue(
+                    'spurious' in std_err.getvalue(), "t2:%s" %
+                    (std_err.getvalue()))
 
     def test_flush_and_sync(self):
         flush_and_sync(sys.stdout)
 
-
     def test_handle_error(self):
         try:
             dont_alarm(Trace.STDERR_SEVERITIES)
-        except:
-            with mock.patch('sys.stdout', new = StringIO.StringIO()) as _out:
+        except BaseException:
+            with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
                 Trace.handle_error()
-                self.assertTrue('ValueError' in _out.getvalue(), _out.getvalue())
+                self.assertTrue(
+                    'ValueError' in _out.getvalue(),
+                    _out.getvalue())
 
     def test_log_stack_trace(self):
         try:
-            with open('/var/lib/does/not/exist','r') as not_there:
+            with open('/var/lib/does/not/exist', 'r') as not_there:
                 lines = not_there.readlines()
-        except:
-            with mock.patch('sys.stderr', new = StringIO.StringIO()) as _out:
+        except BaseException:
+            with mock.patch('sys.stderr', new=StringIO.StringIO()) as _out:
                 Trace.log_stack_trace()
-                self.assertTrue('Failure writing message to log' in _out.getvalue(), _out.getvalue())
-                self.assertTrue('in log_stack_trace' in _out.getvalue(), _out.getvalue())
-                self.assertTrue('in test_log_stack_trace' in _out.getvalue(), _out.getvalue())
+                self.assertTrue(
+                    'Failure writing message to log' in _out.getvalue(),
+                    _out.getvalue())
+                self.assertTrue(
+                    'in log_stack_trace' in _out.getvalue(),
+                    _out.getvalue())
+                self.assertTrue(
+                    'in test_log_stack_trace' in _out.getvalue(),
+                    _out.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/tests/test_Trace.py
+++ b/src/tests/test_Trace.py
@@ -1,0 +1,236 @@
+import unittest
+import sys
+import traceback
+import os
+import mock
+import StringIO
+import pwd
+import time
+import types
+import threading
+import event_relay_messages
+import event_relay_client
+import e_errors
+import enstore_constants
+
+import Trace
+from Trace import *
+
+DONT_ALARM_CAPABLE_LIST  = [e_errors.EMAIL, e_errors.ERROR, e_errors.USER_ERROR ]
+# an alarm function to test Trace.py with
+def alarm_func_0(time, pid, name, root_error,
+		   severity, condition, remedy_type, args):
+    """
+    Alarm function
+
+    :type time: :obj:`float`
+    :arg time: time issued. Even though this implementation of alarm_func() does not use the time
+               parameter, others will.
+    :type pid: :obj:`int`
+    :arg pid: process id
+    :type name: :obj:`str`
+    :arg name: client name
+    :type root_error: :obj:`str`
+    :arg root_error: alarm cause
+    :type severity: :obj:`str`
+    :arg severity: alarm severity
+    :type condition: :obj:`str`
+    :arg condition: alarm condition
+    :type remedy_type: :obj:`str`
+    :arg remedy_type: alarm remedy type
+    :type args: :obj:`list`
+    :arg args: additional arguments
+    """
+
+    __pychecker__ = "unusednames=time"
+
+    # translate severity to text
+    if type(severity) == types.IntType:
+        severity = e_errors.sevdict.get(severity,
+                                        e_errors.sevdict[e_errors.ERROR])
+    ticket = {}
+    ticket['work'] = "post_alarm"
+    ticket[enstore_constants.UID] = os.getuid()
+    ticket[enstore_constants.PID] = pid
+    ticket[enstore_constants.SOURCE] = name
+    ticket[enstore_constants.SEVERITY] = severity
+    ticket[enstore_constants.ROOT_ERROR] = root_error
+    ticket[enstore_constants.CONDITION] = condition
+    ticket[enstore_constants.REMEDY_TYPE] = remedy_type
+    ticket['text'] = args
+    log_msg = "%s, %s (severity : %s)"%(root_error, args, severity)
+
+    Trace.log(e_errors.ALARM, log_msg, Trace.MSG_ALARM)
+
+# a log function to test Trace.py with
+def log_func_0 (timestamp, pid, name, args):
+    #Even though this implimentation of log_func() does not use the time
+    # parameter, others will.
+    __pychecker__ = "unusednames=time"
+
+    severity = args[0]
+    msg = args[1]
+    logmsg = 'log_func_0 %s %.6d %.8s %s %s  %s'%(time.ctime(timestamp), pid, usr, e_errors.sevdict[severity], name, msg)
+    if severity in Trace.STDERR_SEVERITIES:
+        print >> sys.stderr , logmsg
+    else:
+        print logmsg
+    return None
+
+
+class TestTrace(unittest.TestCase):
+    def setUp(self):
+        self.logname = 'TraceUnitTest'
+        self.threadname = 'MainThread'
+        init(self.logname, 'yes')
+
+    def test_get_set_logname(self):
+        lg = get_logname()
+        self.assertEqual(lg, self.logname)
+        set_logname('FOO')
+        lg = get_logname()
+        self.assertEqual(lg, 'FOO')
+    
+    def test_get_threadname(self):
+        tn = get_threadname()
+        self.assertEqual(tn, self.threadname)
+
+    def test_log_thread(self):
+        log_thread(1)
+        self.assertTrue(Trace.include_threadname)
+        log_thread(0)
+        self.assertFalse(Trace.include_threadname)
+
+    def test_notify(self):
+        msg = 'this is a message'
+        notify(msg)
+
+    def test_log_functionality(self):
+        msg = 'this is  a log msg'
+        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+            log(e_errors.INFO, msg)
+            self.assertTrue( msg in std_out.getvalue(), std_out.getvalue())
+        set_log_func(log_func_0)
+        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+            log(e_errors.INFO, msg)
+            self.assertTrue( msg in std_out.getvalue(), std_out.getvalue())
+            self.assertTrue( 'log_func_0'  in std_out.getvalue(), std_out.getvalue())
+
+    def test_log_to_stderr(self):
+        msg = 'this is  a log msg'
+        for severity in Trace.STDERR_SEVERITIES:
+            with mock.patch('sys.stderr', new = StringIO.StringIO()) as std_err:
+                log(severity, msg)
+                self.assertTrue( msg in std_err.getvalue(), std_err.getvalue())
+            set_log_func(log_func_0)
+            with mock.patch('sys.stderr', new = StringIO.StringIO()) as std_err:
+                log(severity, msg)
+                self.assertTrue( msg in std_err.getvalue(), std_err.getvalue())
+                self.assertTrue( 'log_func_0'  in std_err.getvalue(), std_err.getvalue())
+    
+    def test_alarm_functionality(self):
+        msg = 'this is  an alarm!!!'
+        #test default alarm function
+        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+            alarm(e_errors.ALARM, msg)
+            self.assertTrue( 'default_alarm_func'  in std_out.getvalue(), std_out.getvalue())
+
+        # test setting custom alarm
+        set_alarm_func(alarm_func_0)
+        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+            alarm(e_errors.ALARM, msg)
+            self.assertTrue( msg in std_out.getvalue(), std_out.getvalue())
+
+    def test_do_and_dont_print(self):
+        self.assertEqual(len(print_levels.keys()), 0)
+        do_print(Trace.STDERR_SEVERITIES)
+        self.assertEqual(len(print_levels.keys()), len(Trace.STDERR_SEVERITIES))
+        dont_print(Trace.STDERR_SEVERITIES)
+        self.assertEqual(len(print_levels.keys()), 0)
+
+    def test_do_and_dont_log(self):
+        self.assertEqual(len(log_levels.keys()), 0)
+        do_log(Trace.STDERR_SEVERITIES)
+        self.assertEqual(len(log_levels.keys()), len(Trace.STDERR_SEVERITIES))
+        dont_log(Trace.STDERR_SEVERITIES)
+        self.assertEqual(len(log_levels.keys()), 0)
+
+
+    def test_do_and_dont_message(self):
+        self.assertEqual(len(message_levels.keys()), 0)
+        do_message(Trace.STDERR_SEVERITIES)
+        self.assertEqual(len(message_levels.keys()), len(Trace.STDERR_SEVERITIES))
+        try:
+            dont_message(Trace.STDERR_SEVERITIES)
+            self.assertTrue(False)
+        except ValueError:
+            pass
+        dont_message(DONT_ALARM_CAPABLE_LIST)
+        self.assertEqual(len(message_levels.keys()), 1)
+
+    def test_do_and_dont_alarm(self):
+        self.assertEqual(len(alarm_levels.keys()), 0)
+        do_alarm(Trace.STDERR_SEVERITIES)
+        self.assertEqual(len(alarm_levels.keys()), len(Trace.STDERR_SEVERITIES))
+        try:
+            dont_alarm(Trace.STDERR_SEVERITIES)
+            self.assertTrue(False)
+        except ValueError:
+            pass
+        dont_alarm(DONT_ALARM_CAPABLE_LIST)
+        self.assertEqual(len(alarm_levels.keys()), 1)
+
+    def test_trunc_length(self):
+        msg = "this is a very very very "
+        msg += "long message.  It has no "
+        msg += "real  value other than to"
+        msg += "be on the verbose side.  "
+        msg += "It is possible that in   "
+        msg += "the future some  AI will "
+        msg += "attempt to analyze this, "
+        msg += "perhaps drawing the wrong"
+        msg += "conclusions from a spurio"
+        msg += "ous correlation. Oh well."
+
+        len1 = len(msg)
+        max_msg_size = set_max_message_size(len1/2)
+        msg2 = trunc(msg)
+        len2 = len(msg2)
+        self.assertTrue(len2 < len1)
+
+
+    def test_trace(self):
+        ticket = {'status':'test'}
+        dont_print(1)
+        do_alarm(1)
+        do_log(1)
+        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+            with mock.patch('sys.stderr', new = StringIO.StringIO()) as std_err:
+       	        trace(1, 'a spurious test message: %s' % (ticket,))
+                self.assertTrue('spurious' in std_err.getvalue(), "t2:%s" %(std_err.getvalue()))
+    
+
+    def test_flush_and_sync(self):
+        flush_and_sync(sys.stdout)
+
+
+    def test_handle_error(self):
+        try:
+            dont_alarm(Trace.STDERR_SEVERITIES)
+        except:
+            with mock.patch('sys.stdout', new = StringIO.StringIO()) as _out:
+                Trace.handle_error()
+                self.assertTrue('ValueError' in _out.getvalue(), _out.getvalue())
+
+    def test_log_stack_trace(self):
+        try:
+            with open('/var/lib/does/not/exist','r') as not_there:
+                lines = not_there.readlines()
+        except:
+            with mock.patch('sys.stderr', new = StringIO.StringIO()) as _out:
+                Trace.log_stack_trace()
+                self.assertTrue('Failure writing message to log' in _out.getvalue(), _out.getvalue())
+                self.assertTrue('in log_stack_trace' in _out.getvalue(), _out.getvalue())
+                self.assertTrue('in test_log_stack_trace' in _out.getvalue(), _out.getvalue())
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_manage_queue.py
+++ b/src/tests/test_manage_queue.py
@@ -1,0 +1,552 @@
+import unittest
+import sys
+import string
+import threading
+import time
+import mock
+import StringIO
+import mpq  # binary search / put
+import Trace
+import e_errors
+import hostaddr
+from manage_queue import Request, SortedList, Queue, Atomic_Request_Queue, Request_Queue, compare_priority, compare_value
+
+# utility functions to generate test tickets
+CID = 10
+def new_id():
+    global CID
+    CID += 1
+    return CID
+
+def cid():
+    global CID
+    return CID
+
+def mk_ticket(unique_id=0, basepri=0, adminpri=0, work="read_from_hsm",
+              external_label="external_label_0", location_cookie=5, storage_group='storage_group_0',
+              volume_family="volume_family_0", file_family="file_family_0", wrapper="wrapper_0",
+              size_bytes=0, callback_addr=None, comment=None):
+
+    global CID
+    if not unique_id:
+        unique_id = new_id()
+    if unique_id > CID:
+        CID = unique_id
+ 
+    if not basepri:
+        basepri = CID
+
+    if not adminpri:
+        adminpri = CID
+
+    if not size_bytes:
+        size_bytes = CID * 1024
+
+    t1 = {}
+    t1["encp"] = {}
+    t1['fc'] = {}
+    t1['vc'] = {}
+    t1['wrapper'] = {}
+    t1["times"] = {}
+    t1["unique_id"] = unique_id
+    t1["encp"]["basepri"] = basepri
+    t1['encp']['adminpri'] = adminpri
+    t1["times"]["t0"] = time.time()
+    t1['work'] = work
+    t1['fc']['external_label'] = external_label
+    t1['fc']['location_cookie'] = location_cookie
+    t1['vc']['storage_group'] = storage_group
+    t1['vc']['volume_family'] = volume_family
+    t1['vc']['file_family'] = file_family
+    t1['vc']['wrapper'] = wrapper
+    t1["wrapper"]["size_bytes"] = size_bytes
+    t1['callback_addr'] = callback_addr
+    t1['comment'] = comment
+    return t1
+
+
+ 
+class TestRequest(unittest.TestCase):
+
+    def setUp(self):
+        t = mk_ticket() 
+        self.req = Request(1,1000,t)
+
+    def test___init__(self):
+        self.assertTrue(isinstance(self.req, Request))
+
+    def test___cmp__(self):
+        t2 = mk_ticket(2,2,2)
+        r2 = Request(2,1000,t2)
+        val = self.req.__cmp__(r2)
+        self.assertEqual(val, -1)
+        val2 = r2.__cmp__(self.req)
+        self.assertEqual(val2, 1)
+        val3 = r2.__cmp__(r2)
+        self.assertEqual(val3, 0)
+
+    def test___repr__(self):
+        rep = self.req.__repr__()
+        self.assertTrue('<priority 1 value 1000 id ' in rep, rep)
+
+    def test_change_pri(self):
+        orig = self.req.pri
+        new = orig + 10
+        self.req.change_pri(new)
+        self.assertEqual(self.req.pri, new)
+        self.assertEqual(self.req.ticket['encp']['curpri'], new)
+
+
+
+class TestSortedList(unittest.TestCase):
+
+    def setUp(self):
+        self.slp = SortedList(compare_priority, 1, 'slp')
+        self.slv = SortedList(compare_value, 0, 1, 'slv')
+        self.r1 = Request(1,1000,mk_ticket(1,1,1))
+        self.r2 = Request(2,2000,mk_ticket(2,2,2))
+        self.slp.put(self.r1)
+        self.slp.put(self.r2)
+
+    def test___init__(self):
+        self.assertTrue(isinstance(self.slp, SortedList))
+        self.assertTrue(isinstance(self.slv, SortedList))
+
+    def test_test(self):
+        rid,stat = self.slp.test(1)
+        self.assertEqual(rid,1)
+        self.assertEqual(stat, e_errors.OK)
+        rid,stat = self.slp.test(99)
+        self.assertEqual(rid,0)
+        self.assertTrue(stat is None)
+
+    def test_find(self):
+        req,stat = self.slp.find(1)
+        self.assertEqual(req.unique_id,1)
+        self.assertEqual(stat, e_errors.OK)
+        req,stat = self.slp.find(99)
+        self.assertTrue(req is None)
+        self.assertTrue(stat is None)
+
+    def test_get_tickets(self):
+        tickets = self.slp.get_tickets()
+        self.assertTrue(len(tickets) > 0)
+
+    def test_put(self):
+        tickets = self.slp.get_tickets()
+        for rid in self.slp.ids:
+            req,stat  = self.slp.find(rid)
+            self.slv.put(req)
+        ptickets = self.slv.get_tickets()
+        self.assertTrue(len(tickets) == len(ptickets))
+       
+    def test_get_get_next(self):
+       r1 = self.slp.get()
+       r2 = self.slp.get_next()
+       self.assertTrue(isinstance(r1, Request))
+       self.assertTrue(isinstance(r2, Request))
+       self.assertTrue(r1.__cmp__(r2) != 0 )       
+
+    def test_update(self):
+        old_highest_pri = self.slp.highest_pri
+        self.slp.update(True)
+        new_highest_pri = self.slp.highest_pri
+        self.assertTrue(new_highest_pri > old_highest_pri)
+
+    def test_rm(self):
+        r1 = self.slp.get()
+        rid = r1.unique_id
+        self.slp.rm(r1)
+        r1,stat = self.slp.find(rid)
+        self.assertTrue(r1 is None)
+        
+
+    def test_delete(self):
+        r1 = self.slp.get()
+        rid = r1.unique_id
+        self.slp.delete(r1)
+        r1,stat = self.slp.find(rid)
+        self.assertTrue(r1 is None)
+
+    def test_change_pri(self):
+        r1 = self.slp.get()
+        r1_pri = r1.pri
+        r1_id = r1.unique_id
+        self.slp.change_pri(r1, r1_pri+100)
+        r2,stat  = self.slp.find(r1_id)
+        r2_pri = r2.pri
+        self.assertTrue(r2_pri == (r1_pri+100))
+
+
+    def test_wprint(self):
+        with mock.patch('sys.stdout', new = StringIO.StringIO()) as _out:
+            self.slp.wprint()
+            self.assertTrue('LIST LENGTH' in _out.getvalue(), _out.getvalue())
+            self.assertTrue('<priority ' in _out.getvalue(), _out.getvalue())
+
+
+    def test_sprint(self):
+        strm = self.slp.sprint()
+        self.assertTrue('LIST LENGTH' in strm, strm)
+        self.assertTrue('<priority ' in strm, strm)
+
+class TestQueue(unittest.TestCase):
+
+    def setUp(self):
+        self.q = Queue()
+        self.r_list = []
+        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        self.r_list.append(rq)
+        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        self.r_list.append(rq)
+        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        self.r_list.append(rq)
+        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        self.r_list.append(rq)
+        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        self.r_list.append(rq)
+        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        self.r_list.append(rq)
+
+    def test___init__(self):
+        self.assertTrue(isinstance(self.q, Queue)) 
+
+    def test_put_test_test(self):
+
+        # test basic put() and test() 
+        t0 = mk_ticket(1, work='write_to_hsm')
+        r0,stat = self.q.put(1, t0) 
+        self.assertTrue(isinstance(r0, Request))
+        tst_rslt = self.q.test(t0)
+        self.assertEqual(t0['unique_id'],tst_rslt[0],"%s|%s"%(t0['unique_id'],tst_rslt[0]))
+        t1 = mk_ticket(work='read_from_hsm')
+        r1,stat = self.q.put(1, t1)
+        self.assertTrue(isinstance(r1, Request))
+        tst_rslt = self.q.test(t1)
+        self.assertEqual(t1['unique_id'],tst_rslt[0],"%s|%s"%(t1['unique_id'],tst_rslt[0]))
+
+        # test putting same ticket twice
+        r2,stat = self.q.put(1, t0)
+        self.assertTrue(r2 is None)
+
+        # test putting ticket with wrong work type
+        r3,stat = self.q.put(1, mk_ticket(work='do_nothing'))
+        self.assertTrue(r3 is None)
+        self.assertEqual(stat, e_errors.WRONGPARAMETER)
+
+        # verify that test() on ticket not in Queue behaves correctly
+        tx = mk_ticket()
+        tst_rslt = self.q.test(tx)
+        self.assertFalse(tst_rslt[0], tst_rslt) 
+
+        
+    def test_wprint(self):
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
+            self.q.wprint()
+            self.assertTrue('KEY volume_family_0' in _out.getvalue(), _out.getvalue())
+            self.assertTrue('KEY external_label_0' in _out.getvalue(), _out.getvalue())
+
+
+    def test_sprint(self):
+        spr = self.q.sprint()
+        self.assertTrue('KEY volume_family_0' in spr, spr)
+        self.assertTrue('KEY external_label_0' in spr, spr)
+
+
+    def test_get_queue(self):
+        q1 = self.q.get_queue()
+        self.assertTrue(isinstance(q1, list))
+        q2 = self.q.get_queue(queue_key='opt')
+        self.assertTrue(isinstance(q2, list))
+        #test a bad key
+        with mock.patch('sys.stderr', new=StringIO.StringIO()) as _out:
+            try:
+                q3 = self.q.get(queue_key='bad_key')
+                self.assertTrue(False)
+            except TypeError, KeyError:
+                pass
+
+        
+    def test_get(self):
+        rslt = self.q.get('volume_family_0')
+        self.assertTrue(isinstance(rslt, Request))
+        rslt = self.q.get('external_label_0')
+        self.assertTrue(isinstance(rslt, Request))
+        rslt = self.q.get('non_existent_key')
+        self.assertTrue(rslt is None)
+    
+    def test_get_next(self):
+        rslt = self.q.get_next('volume_family_0')
+        self.assertTrue(isinstance(rslt, Request))
+        rslt = self.q.get_next('external_label_0')
+        self.assertTrue(isinstance(rslt, Request))
+        rslt = self.q.get_next('non_existent_key')
+        self.assertTrue(rslt is None)
+
+
+    def test_what_key(self):
+        for rq in self.r_list[:3]:
+            akey = self.q.what_key(rq)
+            self.assertEqual('volume_family_0',akey,akey)
+        for rq in self.r_list[3:]:
+            akey = self.q.what_key(rq)
+            self.assertEqual('external_label_0',akey,akey)
+        # note that what_key() doesnt care if request is in Queue
+        rq=Request(new_id(),cid(), mk_ticket(cid()))
+        akey = self.q.what_key(rq)
+        self.assertEqual('external_label_0', akey, akey)
+       
+
+    def test_delete(self):
+        # find a req in queue
+        req = self.q.find(self.r_list[0].unique_id)
+        self.assertTrue(req is not None)
+        # delete
+        self.q.delete(req)
+        # test if still in queue
+        req2 = self.q.find(self.r_list[0].unique_id)
+        self.assertTrue(req2 is None)
+   
+
+    def test_change_pri(self):
+        req = self.r_list[0]
+        pri = req.pri
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
+            req2 = self.q.change_pri(req, pri+100)
+            self.assertTrue(req2.pri == pri+100)
+
+    def test_find(self):
+        req1 = self.q.find(self.r_list[0].unique_id)
+        self.assertEqual(req1, self.r_list[0])
+        req2 = Request(new_id(), cid(), mk_ticket(cid()))
+        req3 = self.q.find(req2.unique_id)
+        self.assertTrue(req3  is None)
+
+    def test_update_priority(self):
+        u1 = self.q.update_priority()
+        self.assertNotEqual({},u1,u1)
+
+class TestAtomic_Request_Queue(unittest.TestCase):
+    def setUp(self):
+        self.arq = Atomic_Request_Queue()
+        self.r_list = []
+        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        self.r_list.append(rq)
+        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        self.r_list.append(rq)
+        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        self.r_list.append(rq)
+        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        self.r_list.append(rq)
+        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        self.r_list.append(rq)
+        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        self.r_list.append(rq)
+
+
+    def test___init__(self):
+        self.assertTrue(isinstance(self.arq, Atomic_Request_Queue))
+        #self.arq.wprint()
+
+    def test_update(self):
+        keylist = self.arq.tags.keys
+        for k in self.arq.ref.keys():
+            keylist.append(k)
+        # leaving the debug stuff in here for now
+        # to remind me that there may be a bunch of unneeded
+        # inserts and deletes in update()
+        #import pdb; pdb.set_trace()
+        for k in keylist:
+            #print "k=%s" % k
+            for req in self.r_list:
+                #print "req=%s" % req
+                ret = self.arq.update(req,k)
+                #print "ret output = %s" % ret
+
+    def test_get_tags(self):
+        tags = self.arq.get_tags()
+        self.assertEqual(tags, self.arq.tags.keys)
+
+    def test_get_sg(self):
+        tags = self.arq.get_tags()
+        for tag in tags:
+            #print "tag=%s" % tag
+            #import pdb; pdb.set_trace()
+            #sg = self.arq.get_sg(kt)
+            #self.assertEqual(sg, self.arq.tags[kt])
+            # bug in get_sg() throws exception
+            # here is correct (I think!) algorithm
+            if tag in self.arq.write_queue.queue:
+                sg = self.arq.write_queue.queue[tag]['opt'].get().sg
+            elif tag in self.arq.read_queue.queue:
+                sg =  self.arq.read_queue.queue[tag]['opt'].get().sg
+            else:
+                sg = None
+            #print "tag:%s storage_group:%s" % (tag,sg)
+
+
+    def test_put_test_find(self):
+        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        rq2 = self.arq.find(rq.unique_id)
+        self.assertEqual(rq, rq2)
+
+    def test_test(self):
+        for req in self.r_list:
+            rid,stat = self.arq.test(req.ticket)
+            self.assertNotEqual(rid, 0)
+        tik = mk_ticket()
+        rid,stat = self.arq.test(tik)
+        self.assertEqual(rid,0)
+
+    def test_delete(self):
+        req = self.arq.find(self.r_list[0].unique_id)
+        self.assertTrue(req is not  None)
+        self.arq.delete(req)
+        req2 = self.arq.find(req.unique_id)
+        self.assertTrue(req2 is None)
+
+    def test_get(self):
+        req = self.arq.get()
+        self.assertTrue(isinstance(req, Request))
+        req2 = self.arq.get(next=1)
+        self.assertNotEqual(req, req2)
+
+    def test_get_queue(self):
+        que = self.arq.get_queue()
+        # returns a tuple of two lists of dicts
+        self.assertTrue(isinstance(que, tuple))
+        self.assertTrue(len(que)==2)
+        self.assertTrue(isinstance(que[0], list))
+        self.assertTrue(isinstance(que[0][0], dict))
+       
+
+    def test_change_pri(self):
+        req = self.arq.find(self.r_list[0].unique_id)
+        self.assertTrue(req.pri is not  None)
+        r2 = req.pri+100
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
+            self.arq.change_pri(req, r2)
+        req = self.arq.find(self.r_list[0].unique_id)
+        self.assertEqual(req.pri, r2)
+
+    def test_wprint(self):
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
+            self.arq.wprint()
+            self.assertTrue("LIST LENGTH" in _out.getvalue())
+            self.assertTrue("WRITE QUEUE" in _out.getvalue())
+           
+
+    def test_sprint(self):
+        spr = self.arq.sprint()
+        self.assertTrue("LIST LENGTH" in spr)
+        self.assertTrue("WRITE QUEUE" in spr)
+
+ 
+class TestRequest_Queue(unittest.TestCase):
+    
+    def setUp(self):
+        self.rq = Request_Queue()
+        self.r_list = []
+        req = self.rq.put(mk_ticket(work='write_to_hsm'))
+        self.r_list.append(req)
+        req = self.rq.put(mk_ticket(work='write_to_hsm'))
+        self.r_list.append(req)
+        req = self.rq.put(mk_ticket(work='write_to_hsm'))
+        self.r_list.append(req)
+        req = self.rq.put(mk_ticket(work='read_from_hsm'))
+        self.r_list.append(req)
+        req = self.rq.put(mk_ticket(work='read_from_hsm'))
+        self.r_list.append(req)
+        req = self.rq.put(mk_ticket(work='read_from_hsm'))
+        self.r_list.append(req)
+
+    def test___init__(self):
+        self.assertTrue(isinstance(self.rq, Request_Queue))
+
+
+    def test_get_tags_and_sg(self):
+        tags = self.rq.get_tags()
+        self.assertTrue(len(tags) > 0)
+        for t in tags:
+            sg = self.rq.get_sg(t)
+            self.assertNotEqual('',sg)
+
+
+    def test_put_and_test(self):
+        tk = mk_ticket(work='read_from_hsm')
+        req = self.rq.put(tk)
+        rslt = self.rq.test(tk)
+        self.assertEqual(rslt[0], req[0].unique_id)
+
+
+    def test_find_and_delete_and_change_pri(self):
+        req = self.rq.find(self.r_list[0][0].unique_id)
+        self.assertTrue(isinstance(req, Request))
+        self.rq.delete(req)
+        req = self.rq.find(self.r_list[0][0].unique_id)
+        self.assertTrue(req is None)
+        #test alternate pathway through find()
+        req = self.rq.find(self.r_list[-1][0].unique_id)
+        self.assertTrue(isinstance(req, Request))
+        self.rq.delete(req)
+        req = self.rq.find(self.r_list[-1][0].unique_id)
+        self.assertTrue(req is None)
+        req = self.rq.find(self.r_list[1][0].unique_id)
+        self.assertTrue(isinstance(req, Request))
+        pri = req.pri
+        newpri = pri + 100
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
+            self.rq.change_pri(req, newpri)
+        req = self.rq.find(self.r_list[1][0].unique_id)
+        self.assertEqual(req.pri, newpri)
+
+
+    def test_start_cycle_and_get_admin_request(self):
+        try:
+            req = self.rq.get_admin_request()
+        except AttributeError:
+            pass # need to start_cycle or get_admin_request fails 
+        self.rq.start_cycle()
+        req = self.rq.get_admin_request()
+        self.assertTrue(isinstance(req, Request))
+
+        
+
+    def test_get(self):
+        try:
+            req = self.rq.get()
+        except AttributeError:
+            pass # need to start_cycle or get()  fails
+        self.rq.start_cycle()
+        req = self.rq.get()
+        req2 = self.rq.get(next=1)
+        self.assertNotEqual(req, req2)
+
+    def test_get_queue(self):
+        # used by library_manager
+        # adm_queue, write_queue, read_queue
+        q = self.rq.get_queue() 
+        self.assertTrue(isinstance(q, tuple))
+        self.assertTrue(len(q) == 3)
+        self.assertTrue(isinstance(q[0], list))
+        self.assertTrue(isinstance(q[1], list))
+        self.assertTrue(isinstance(q[2], list))
+
+    def test_wprint(self):
+        with mock.patch('sys.stdout',  new=StringIO.StringIO()) as _out:
+            self.rq.wprint()
+            self.assertTrue('ADMIN QUEUE' in _out.getvalue(), _out.getvalue())
+            self.assertTrue('WRITE QUEUE' in _out.getvalue(), _out.getvalue())
+            self.assertTrue('REGULAR QUEUE' in _out.getvalue(), _out.getvalue())
+
+    def test_sprint(self):
+        s = self.rq.sprint()
+        self.assertTrue('ADMIN QUEUE' in s)
+        self.assertTrue('WRITE QUEUE' in s)
+        self.assertTrue('REGULAR QUEUE' in s)
+        
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_manage_queue.py
+++ b/src/tests/test_manage_queue.py
@@ -13,14 +13,18 @@ from manage_queue import Request, SortedList, Queue, Atomic_Request_Queue, Reque
 
 # utility functions to generate test tickets
 CID = 10
+
+
 def new_id():
     global CID
     CID += 1
     return CID
 
+
 def cid():
     global CID
     return CID
+
 
 def mk_ticket(unique_id=0, basepri=0, adminpri=0, work="read_from_hsm",
               external_label="external_label_0", location_cookie=5, storage_group='storage_group_0',
@@ -32,7 +36,7 @@ def mk_ticket(unique_id=0, basepri=0, adminpri=0, work="read_from_hsm",
         unique_id = new_id()
     if unique_id > CID:
         CID = unique_id
- 
+
     if not basepri:
         basepri = CID
 
@@ -65,19 +69,18 @@ def mk_ticket(unique_id=0, basepri=0, adminpri=0, work="read_from_hsm",
     return t1
 
 
- 
 class TestRequest(unittest.TestCase):
 
     def setUp(self):
-        t = mk_ticket() 
-        self.req = Request(1,1000,t)
+        t = mk_ticket()
+        self.req = Request(1, 1000, t)
 
     def test___init__(self):
         self.assertTrue(isinstance(self.req, Request))
 
     def test___cmp__(self):
-        t2 = mk_ticket(2,2,2)
-        r2 = Request(2,1000,t2)
+        t2 = mk_ticket(2, 2, 2)
+        r2 = Request(2, 1000, t2)
         val = self.req.__cmp__(r2)
         self.assertEqual(val, -1)
         val2 = r2.__cmp__(self.req)
@@ -97,14 +100,13 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(self.req.ticket['encp']['curpri'], new)
 
 
-
 class TestSortedList(unittest.TestCase):
 
     def setUp(self):
         self.slp = SortedList(compare_priority, 1, 'slp')
         self.slv = SortedList(compare_value, 0, 1, 'slv')
-        self.r1 = Request(1,1000,mk_ticket(1,1,1))
-        self.r2 = Request(2,2000,mk_ticket(2,2,2))
+        self.r1 = Request(1, 1000, mk_ticket(1, 1, 1))
+        self.r2 = Request(2, 2000, mk_ticket(2, 2, 2))
         self.slp.put(self.r1)
         self.slp.put(self.r2)
 
@@ -113,18 +115,18 @@ class TestSortedList(unittest.TestCase):
         self.assertTrue(isinstance(self.slv, SortedList))
 
     def test_test(self):
-        rid,stat = self.slp.test(1)
-        self.assertEqual(rid,1)
+        rid, stat = self.slp.test(1)
+        self.assertEqual(rid, 1)
         self.assertEqual(stat, e_errors.OK)
-        rid,stat = self.slp.test(99)
-        self.assertEqual(rid,0)
+        rid, stat = self.slp.test(99)
+        self.assertEqual(rid, 0)
         self.assertTrue(stat is None)
 
     def test_find(self):
-        req,stat = self.slp.find(1)
-        self.assertEqual(req.unique_id,1)
+        req, stat = self.slp.find(1)
+        self.assertEqual(req.unique_id, 1)
         self.assertEqual(stat, e_errors.OK)
-        req,stat = self.slp.find(99)
+        req, stat = self.slp.find(99)
         self.assertTrue(req is None)
         self.assertTrue(stat is None)
 
@@ -135,17 +137,17 @@ class TestSortedList(unittest.TestCase):
     def test_put(self):
         tickets = self.slp.get_tickets()
         for rid in self.slp.ids:
-            req,stat  = self.slp.find(rid)
+            req, stat = self.slp.find(rid)
             self.slv.put(req)
         ptickets = self.slv.get_tickets()
         self.assertTrue(len(tickets) == len(ptickets))
-       
+
     def test_get_get_next(self):
-       r1 = self.slp.get()
-       r2 = self.slp.get_next()
-       self.assertTrue(isinstance(r1, Request))
-       self.assertTrue(isinstance(r2, Request))
-       self.assertTrue(r1.__cmp__(r2) != 0 )       
+        r1 = self.slp.get()
+        r2 = self.slp.get_next()
+        self.assertTrue(isinstance(r1, Request))
+        self.assertTrue(isinstance(r2, Request))
+        self.assertTrue(r1.__cmp__(r2) != 0)
 
     def test_update(self):
         old_highest_pri = self.slp.highest_pri
@@ -157,116 +159,118 @@ class TestSortedList(unittest.TestCase):
         r1 = self.slp.get()
         rid = r1.unique_id
         self.slp.rm(r1)
-        r1,stat = self.slp.find(rid)
+        r1, stat = self.slp.find(rid)
         self.assertTrue(r1 is None)
-        
 
     def test_delete(self):
         r1 = self.slp.get()
         rid = r1.unique_id
         self.slp.delete(r1)
-        r1,stat = self.slp.find(rid)
+        r1, stat = self.slp.find(rid)
         self.assertTrue(r1 is None)
 
     def test_change_pri(self):
         r1 = self.slp.get()
         r1_pri = r1.pri
         r1_id = r1.unique_id
-        self.slp.change_pri(r1, r1_pri+100)
-        r2,stat  = self.slp.find(r1_id)
+        self.slp.change_pri(r1, r1_pri + 100)
+        r2, stat = self.slp.find(r1_id)
         r2_pri = r2.pri
-        self.assertTrue(r2_pri == (r1_pri+100))
-
+        self.assertTrue(r2_pri == (r1_pri + 100))
 
     def test_wprint(self):
-        with mock.patch('sys.stdout', new = StringIO.StringIO()) as _out:
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
             self.slp.wprint()
             self.assertTrue('LIST LENGTH' in _out.getvalue(), _out.getvalue())
             self.assertTrue('<priority ' in _out.getvalue(), _out.getvalue())
-
 
     def test_sprint(self):
         strm = self.slp.sprint()
         self.assertTrue('LIST LENGTH' in strm, strm)
         self.assertTrue('<priority ' in strm, strm)
 
+
 class TestQueue(unittest.TestCase):
 
     def setUp(self):
         self.q = Queue()
         self.r_list = []
-        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        rq, stat = self.q.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
         self.r_list.append(rq)
-        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        rq, stat = self.q.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
         self.r_list.append(rq)
-        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        rq, stat = self.q.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
         self.r_list.append(rq)
-        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        rq, stat = self.q.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
         self.r_list.append(rq)
-        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        rq, stat = self.q.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
         self.r_list.append(rq)
-        rq,stat = self.q.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        rq, stat = self.q.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
         self.r_list.append(rq)
 
     def test___init__(self):
-        self.assertTrue(isinstance(self.q, Queue)) 
+        self.assertTrue(isinstance(self.q, Queue))
 
     def test_put_test_test(self):
 
-        # test basic put() and test() 
+        # test basic put() and test()
         t0 = mk_ticket(1, work='write_to_hsm')
-        r0,stat = self.q.put(1, t0) 
+        r0, stat = self.q.put(1, t0)
         self.assertTrue(isinstance(r0, Request))
         tst_rslt = self.q.test(t0)
-        self.assertEqual(t0['unique_id'],tst_rslt[0],"%s|%s"%(t0['unique_id'],tst_rslt[0]))
+        self.assertEqual(
+            t0['unique_id'], tst_rslt[0], "%s|%s" %
+            (t0['unique_id'], tst_rslt[0]))
         t1 = mk_ticket(work='read_from_hsm')
-        r1,stat = self.q.put(1, t1)
+        r1, stat = self.q.put(1, t1)
         self.assertTrue(isinstance(r1, Request))
         tst_rslt = self.q.test(t1)
-        self.assertEqual(t1['unique_id'],tst_rslt[0],"%s|%s"%(t1['unique_id'],tst_rslt[0]))
+        self.assertEqual(
+            t1['unique_id'], tst_rslt[0], "%s|%s" %
+            (t1['unique_id'], tst_rslt[0]))
 
         # test putting same ticket twice
-        r2,stat = self.q.put(1, t0)
+        r2, stat = self.q.put(1, t0)
         self.assertTrue(r2 is None)
 
         # test putting ticket with wrong work type
-        r3,stat = self.q.put(1, mk_ticket(work='do_nothing'))
+        r3, stat = self.q.put(1, mk_ticket(work='do_nothing'))
         self.assertTrue(r3 is None)
         self.assertEqual(stat, e_errors.WRONGPARAMETER)
 
         # verify that test() on ticket not in Queue behaves correctly
         tx = mk_ticket()
         tst_rslt = self.q.test(tx)
-        self.assertFalse(tst_rslt[0], tst_rslt) 
+        self.assertFalse(tst_rslt[0], tst_rslt)
 
-        
     def test_wprint(self):
         with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
             self.q.wprint()
-            self.assertTrue('KEY volume_family_0' in _out.getvalue(), _out.getvalue())
-            self.assertTrue('KEY external_label_0' in _out.getvalue(), _out.getvalue())
-
+            self.assertTrue(
+                'KEY volume_family_0' in _out.getvalue(),
+                _out.getvalue())
+            self.assertTrue(
+                'KEY external_label_0' in _out.getvalue(),
+                _out.getvalue())
 
     def test_sprint(self):
         spr = self.q.sprint()
         self.assertTrue('KEY volume_family_0' in spr, spr)
         self.assertTrue('KEY external_label_0' in spr, spr)
 
-
     def test_get_queue(self):
         q1 = self.q.get_queue()
         self.assertTrue(isinstance(q1, list))
         q2 = self.q.get_queue(queue_key='opt')
         self.assertTrue(isinstance(q2, list))
-        #test a bad key
+        # test a bad key
         with mock.patch('sys.stderr', new=StringIO.StringIO()) as _out:
             try:
                 q3 = self.q.get(queue_key='bad_key')
                 self.assertTrue(False)
-            except TypeError, KeyError:
+            except TypeError as KeyError:
                 pass
 
-        
     def test_get(self):
         rslt = self.q.get('volume_family_0')
         self.assertTrue(isinstance(rslt, Request))
@@ -274,7 +278,7 @@ class TestQueue(unittest.TestCase):
         self.assertTrue(isinstance(rslt, Request))
         rslt = self.q.get('non_existent_key')
         self.assertTrue(rslt is None)
-    
+
     def test_get_next(self):
         rslt = self.q.get_next('volume_family_0')
         self.assertTrue(isinstance(rslt, Request))
@@ -283,19 +287,17 @@ class TestQueue(unittest.TestCase):
         rslt = self.q.get_next('non_existent_key')
         self.assertTrue(rslt is None)
 
-
     def test_what_key(self):
         for rq in self.r_list[:3]:
             akey = self.q.what_key(rq)
-            self.assertEqual('volume_family_0',akey,akey)
+            self.assertEqual('volume_family_0', akey, akey)
         for rq in self.r_list[3:]:
             akey = self.q.what_key(rq)
-            self.assertEqual('external_label_0',akey,akey)
+            self.assertEqual('external_label_0', akey, akey)
         # note that what_key() doesnt care if request is in Queue
-        rq=Request(new_id(),cid(), mk_ticket(cid()))
+        rq = Request(new_id(), cid(), mk_ticket(cid()))
         akey = self.q.what_key(rq)
         self.assertEqual('external_label_0', akey, akey)
-       
 
     def test_delete(self):
         # find a req in queue
@@ -306,47 +308,58 @@ class TestQueue(unittest.TestCase):
         # test if still in queue
         req2 = self.q.find(self.r_list[0].unique_id)
         self.assertTrue(req2 is None)
-   
 
     def test_change_pri(self):
         req = self.r_list[0]
         pri = req.pri
         with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
-            req2 = self.q.change_pri(req, pri+100)
-            self.assertTrue(req2.pri == pri+100)
+            req2 = self.q.change_pri(req, pri + 100)
+            self.assertTrue(req2.pri == pri + 100)
 
     def test_find(self):
         req1 = self.q.find(self.r_list[0].unique_id)
         self.assertEqual(req1, self.r_list[0])
         req2 = Request(new_id(), cid(), mk_ticket(cid()))
         req3 = self.q.find(req2.unique_id)
-        self.assertTrue(req3  is None)
+        self.assertTrue(req3 is None)
 
     def test_update_priority(self):
         u1 = self.q.update_priority()
-        self.assertNotEqual({},u1,u1)
+        self.assertNotEqual({}, u1, u1)
+
 
 class TestAtomic_Request_Queue(unittest.TestCase):
     def setUp(self):
         self.arq = Atomic_Request_Queue()
         self.r_list = []
-        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        rq, stat = self.arq.put(
+            new_id(), mk_ticket(
+                cid(), work='write_to_hsm'))
         self.r_list.append(rq)
-        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        rq, stat = self.arq.put(
+            new_id(), mk_ticket(
+                cid(), work='write_to_hsm'))
         self.r_list.append(rq)
-        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        rq, stat = self.arq.put(
+            new_id(), mk_ticket(
+                cid(), work='write_to_hsm'))
         self.r_list.append(rq)
-        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        rq, stat = self.arq.put(
+            new_id(), mk_ticket(
+                cid(), work='read_from_hsm'))
         self.r_list.append(rq)
-        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        rq, stat = self.arq.put(
+            new_id(), mk_ticket(
+                cid(), work='read_from_hsm'))
         self.r_list.append(rq)
-        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='read_from_hsm'))
+        rq, stat = self.arq.put(
+            new_id(), mk_ticket(
+                cid(), work='read_from_hsm'))
         self.r_list.append(rq)
-
 
     def test___init__(self):
         self.assertTrue(isinstance(self.arq, Atomic_Request_Queue))
-        #self.arq.wprint()
+        # self.arq.wprint()
 
     def test_update(self):
         keylist = self.arq.tags.keys
@@ -360,7 +373,7 @@ class TestAtomic_Request_Queue(unittest.TestCase):
             #print "k=%s" % k
             for req in self.r_list:
                 #print "req=%s" % req
-                ret = self.arq.update(req,k)
+                ret = self.arq.update(req, k)
                 #print "ret output = %s" % ret
 
     def test_get_tags(self):
@@ -379,28 +392,29 @@ class TestAtomic_Request_Queue(unittest.TestCase):
             if tag in self.arq.write_queue.queue:
                 sg = self.arq.write_queue.queue[tag]['opt'].get().sg
             elif tag in self.arq.read_queue.queue:
-                sg =  self.arq.read_queue.queue[tag]['opt'].get().sg
+                sg = self.arq.read_queue.queue[tag]['opt'].get().sg
             else:
                 sg = None
             #print "tag:%s storage_group:%s" % (tag,sg)
 
-
     def test_put_test_find(self):
-        rq,stat = self.arq.put(new_id(), mk_ticket(cid(), work='write_to_hsm'))
+        rq, stat = self.arq.put(
+            new_id(), mk_ticket(
+                cid(), work='write_to_hsm'))
         rq2 = self.arq.find(rq.unique_id)
         self.assertEqual(rq, rq2)
 
     def test_test(self):
         for req in self.r_list:
-            rid,stat = self.arq.test(req.ticket)
+            rid, stat = self.arq.test(req.ticket)
             self.assertNotEqual(rid, 0)
         tik = mk_ticket()
-        rid,stat = self.arq.test(tik)
-        self.assertEqual(rid,0)
+        rid, stat = self.arq.test(tik)
+        self.assertEqual(rid, 0)
 
     def test_delete(self):
         req = self.arq.find(self.r_list[0].unique_id)
-        self.assertTrue(req is not  None)
+        self.assertTrue(req is not None)
         self.arq.delete(req)
         req2 = self.arq.find(req.unique_id)
         self.assertTrue(req2 is None)
@@ -415,15 +429,14 @@ class TestAtomic_Request_Queue(unittest.TestCase):
         que = self.arq.get_queue()
         # returns a tuple of two lists of dicts
         self.assertTrue(isinstance(que, tuple))
-        self.assertTrue(len(que)==2)
+        self.assertTrue(len(que) == 2)
         self.assertTrue(isinstance(que[0], list))
         self.assertTrue(isinstance(que[0][0], dict))
-       
 
     def test_change_pri(self):
         req = self.arq.find(self.r_list[0].unique_id)
-        self.assertTrue(req.pri is not  None)
-        r2 = req.pri+100
+        self.assertTrue(req.pri is not None)
+        r2 = req.pri + 100
         with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
             self.arq.change_pri(req, r2)
         req = self.arq.find(self.r_list[0].unique_id)
@@ -434,16 +447,15 @@ class TestAtomic_Request_Queue(unittest.TestCase):
             self.arq.wprint()
             self.assertTrue("LIST LENGTH" in _out.getvalue())
             self.assertTrue("WRITE QUEUE" in _out.getvalue())
-           
 
     def test_sprint(self):
         spr = self.arq.sprint()
         self.assertTrue("LIST LENGTH" in spr)
         self.assertTrue("WRITE QUEUE" in spr)
 
- 
+
 class TestRequest_Queue(unittest.TestCase):
-    
+
     def setUp(self):
         self.rq = Request_Queue()
         self.r_list = []
@@ -463,14 +475,12 @@ class TestRequest_Queue(unittest.TestCase):
     def test___init__(self):
         self.assertTrue(isinstance(self.rq, Request_Queue))
 
-
     def test_get_tags_and_sg(self):
         tags = self.rq.get_tags()
         self.assertTrue(len(tags) > 0)
         for t in tags:
             sg = self.rq.get_sg(t)
-            self.assertNotEqual('',sg)
-
+            self.assertNotEqual('', sg)
 
     def test_put_and_test(self):
         tk = mk_ticket(work='read_from_hsm')
@@ -478,14 +488,13 @@ class TestRequest_Queue(unittest.TestCase):
         rslt = self.rq.test(tk)
         self.assertEqual(rslt[0], req[0].unique_id)
 
-
     def test_find_and_delete_and_change_pri(self):
         req = self.rq.find(self.r_list[0][0].unique_id)
         self.assertTrue(isinstance(req, Request))
         self.rq.delete(req)
         req = self.rq.find(self.r_list[0][0].unique_id)
         self.assertTrue(req is None)
-        #test alternate pathway through find()
+        # test alternate pathway through find()
         req = self.rq.find(self.r_list[-1][0].unique_id)
         self.assertTrue(isinstance(req, Request))
         self.rq.delete(req)
@@ -500,23 +509,20 @@ class TestRequest_Queue(unittest.TestCase):
         req = self.rq.find(self.r_list[1][0].unique_id)
         self.assertEqual(req.pri, newpri)
 
-
     def test_start_cycle_and_get_admin_request(self):
         try:
             req = self.rq.get_admin_request()
         except AttributeError:
-            pass # need to start_cycle or get_admin_request fails 
+            pass  # need to start_cycle or get_admin_request fails
         self.rq.start_cycle()
         req = self.rq.get_admin_request()
         self.assertTrue(isinstance(req, Request))
-
-        
 
     def test_get(self):
         try:
             req = self.rq.get()
         except AttributeError:
-            pass # need to start_cycle or get()  fails
+            pass  # need to start_cycle or get()  fails
         self.rq.start_cycle()
         req = self.rq.get()
         req2 = self.rq.get(next=1)
@@ -525,7 +531,7 @@ class TestRequest_Queue(unittest.TestCase):
     def test_get_queue(self):
         # used by library_manager
         # adm_queue, write_queue, read_queue
-        q = self.rq.get_queue() 
+        q = self.rq.get_queue()
         self.assertTrue(isinstance(q, tuple))
         self.assertTrue(len(q) == 3)
         self.assertTrue(isinstance(q[0], list))
@@ -533,19 +539,19 @@ class TestRequest_Queue(unittest.TestCase):
         self.assertTrue(isinstance(q[2], list))
 
     def test_wprint(self):
-        with mock.patch('sys.stdout',  new=StringIO.StringIO()) as _out:
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as _out:
             self.rq.wprint()
             self.assertTrue('ADMIN QUEUE' in _out.getvalue(), _out.getvalue())
             self.assertTrue('WRITE QUEUE' in _out.getvalue(), _out.getvalue())
-            self.assertTrue('REGULAR QUEUE' in _out.getvalue(), _out.getvalue())
+            self.assertTrue(
+                'REGULAR QUEUE' in _out.getvalue(),
+                _out.getvalue())
 
     def test_sprint(self):
         s = self.rq.sprint()
         self.assertTrue('ADMIN QUEUE' in s)
         self.assertTrue('WRITE QUEUE' in s)
         self.assertTrue('REGULAR QUEUE' in s)
-        
-
 
 
 if __name__ == "__main__":

--- a/src/tests/test_mpq.py
+++ b/src/tests/test_mpq.py
@@ -1,0 +1,91 @@
+import unittest
+import mock
+import StringIO
+import mpq
+import sys
+import os
+
+class Req(object):
+    def __init__(self,size,priority):
+        self.size=size
+        self.priority=priority
+
+    def __repr__(self):
+        return "<size=%s, priority=%s>" % (self.size, self.priority)
+
+def compare_priority(r1,r2):
+    return -cmp(r1.priority, r2.priority)
+
+def compare_size(r1,r2):
+    return cmp(r1.size,r2.size)
+
+
+
+class TestMPQ(unittest.TestCase):
+
+    def setUp(self):
+        self.reqs = []
+        r1 = Req(size=1, priority=1)
+        r2 = Req(size=2, priority=2)
+        r3 = Req(size=3, priority=3)
+        r4 = Req(size=4, priority=4)
+        self.reqs.append(r1)
+        self.reqs.append(r2)
+        self.reqs.append(r3)
+        self.reqs.append(r4)
+        self.prio_mpq = mpq.MPQ(compare_priority)
+        self.size_mpq  = mpq.MPQ(compare_size)
+
+    def test___init__(self):
+        self.assertTrue(isinstance(self.prio_mpq, mpq.MPQ))
+        self.assertTrue(isinstance(self.size_mpq, mpq.MPQ))
+
+    def perform_insort(self):
+        for itm in self.reqs:
+            self.prio_mpq.insort(itm)
+            self.size_mpq.insort(itm)
+
+    def test_insort(self):
+        self.perform_insort()
+        if os.getenv('DEBUG'):
+            print "\nafter insort:\n"
+            print "self.reqs: %s\n" % self.reqs
+            print "self.prio_mpq: %s\n" % self.prio_mpq
+            print "self.size_mpq: %s\n" % self.size_mpq
+        self.assertNotEqual(self.prio_mpq[0], self.size_mpq[0])
+
+    def test_bisect(self):
+        self.perform_insort()
+        req = Req(size=5, priority=5)
+        bndx = self.prio_mpq.bisect(req)
+        self.assertEqual(bndx, 0)
+        bndx = self.size_mpq.bisect(req)
+        self.assertEqual(bndx, len(self.size_mpq)-1)
+
+    def test_remove(self):
+        self.perform_insort()
+        req = Req(size=5, priority=5)
+
+        # try removing something not in list
+        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+            self.prio_mpq.remove(req)
+            self.assertTrue('exceptions.ValueError' in std_out.getvalue(), std_out.getvalue())
+
+        # try removing something that is in list
+        itm = self.reqs[0]
+        self.prio_mpq.remove(itm)
+        self.assertNotEqual(len(self.reqs), len(self.prio_mpq))   
+        
+    def test___nonzero__(self):
+        self.assertFalse(self.prio_mpq.__nonzero__())
+        self.perform_insort()
+        self.assertTrue(self.prio_mpq.__nonzero__())
+
+    def test___repr__(self):
+        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+            self.perform_insort()
+            print self.prio_mpq
+            self.assertTrue('<size=4, priority=4>' in std_out.getvalue(), std_out.getvalue())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_mpq.py
+++ b/src/tests/test_mpq.py
@@ -5,20 +5,22 @@ import mpq
 import sys
 import os
 
+
 class Req(object):
-    def __init__(self,size,priority):
-        self.size=size
-        self.priority=priority
+    def __init__(self, size, priority):
+        self.size = size
+        self.priority = priority
 
     def __repr__(self):
         return "<size=%s, priority=%s>" % (self.size, self.priority)
 
-def compare_priority(r1,r2):
+
+def compare_priority(r1, r2):
     return -cmp(r1.priority, r2.priority)
 
-def compare_size(r1,r2):
-    return cmp(r1.size,r2.size)
 
+def compare_size(r1, r2):
+    return cmp(r1.size, r2.size)
 
 
 class TestMPQ(unittest.TestCase):
@@ -34,7 +36,7 @@ class TestMPQ(unittest.TestCase):
         self.reqs.append(r3)
         self.reqs.append(r4)
         self.prio_mpq = mpq.MPQ(compare_priority)
-        self.size_mpq  = mpq.MPQ(compare_size)
+        self.size_mpq = mpq.MPQ(compare_size)
 
     def test___init__(self):
         self.assertTrue(isinstance(self.prio_mpq, mpq.MPQ))
@@ -60,32 +62,37 @@ class TestMPQ(unittest.TestCase):
         bndx = self.prio_mpq.bisect(req)
         self.assertEqual(bndx, 0)
         bndx = self.size_mpq.bisect(req)
-        self.assertEqual(bndx, len(self.size_mpq)-1)
+        self.assertEqual(bndx, len(self.size_mpq) - 1)
 
     def test_remove(self):
         self.perform_insort()
         req = Req(size=5, priority=5)
 
         # try removing something not in list
-        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as std_out:
             self.prio_mpq.remove(req)
-            self.assertTrue('exceptions.ValueError' in std_out.getvalue(), std_out.getvalue())
+            self.assertTrue(
+                'exceptions.ValueError' in std_out.getvalue(),
+                std_out.getvalue())
 
         # try removing something that is in list
         itm = self.reqs[0]
         self.prio_mpq.remove(itm)
-        self.assertNotEqual(len(self.reqs), len(self.prio_mpq))   
-        
+        self.assertNotEqual(len(self.reqs), len(self.prio_mpq))
+
     def test___nonzero__(self):
         self.assertFalse(self.prio_mpq.__nonzero__())
         self.perform_insort()
         self.assertTrue(self.prio_mpq.__nonzero__())
 
     def test___repr__(self):
-        with mock.patch('sys.stdout', new = StringIO.StringIO()) as std_out:
+        with mock.patch('sys.stdout', new=StringIO.StringIO()) as std_out:
             self.perform_insort()
             print self.prio_mpq
-            self.assertTrue('<size=4, priority=4>' in std_out.getvalue(), std_out.getvalue())
+            self.assertTrue(
+                '<size=4, priority=4>' in std_out.getvalue(),
+                std_out.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
unit tests for manage_queue.py, Trace.py, and mpq.py

To Be Done:
1) The changes from lists to sets in recent commit 1f1ebf70c1821de2862e3150ce28c1f7629a4c4b broke several unit tests, which were written prior to the commit. I am working on fixing the unit tests
2) Atomic_Request_Queue::get_sg() is revealed as broken as currently implemented, a fix is suggested in the unit test comments
3) I am investigating Atomic_Request_Queue::update() as it seems to do unnecessary deletes followed by re-inserting identical requests in its constituent queues