### PR TITLE
Pull workflow fix

### DIFF
--- a/.github/workflows/build-rpm-and-release.yml
+++ b/.github/workflows/build-rpm-and-release.yml
@@ -31,7 +31,7 @@ jobs:
        source ./rpm_version
        ./build_versioned_spec.sh | tee ~/rpmbuild/SPECS/enstore_rpm.spec
        RELEASE_TYPE="-nonprod"
-       if [ "${GITHUB_REF##*/}" -ne "production" ]; then
+       if [ "${GITHUB_REF##*/}" -e "production" ]; then
          RELEASE_TYPE=""
        fi
        echo "::set-output name=release_name::enstore${RELEASE_TYPE}-${EVersion}-${ERelease}.${ECommit}"


### PR DESCRIPTION
Incorrect comparison was causing nonprod rpms to be produced on prod, and prod on develop