### PR TITLE
avoid picking NOTALLOWED or NOACCESS tapes for vol_read_test

### DIFF
--- a/tools/encp_test_functions
+++ b/tools/encp_test_functions
@@ -1864,12 +1864,13 @@ __volume_read_test()
     encp="$1"
 
     #Snag a volume_read_test volume.
-    volumes=$($enstore_cmd info --vols  2>/dev/null | sed -e '1,1d'  | grep -v ".deleted" | egrep  "[^\s]\.volume\_read\_test\.[^\s]" | awk '{ print $1}')
+    volumes=$($enstore_cmd info --vols  2>/dev/null | sed -e '1,1d'  | grep -v ".deleted" | grep -v NOTALLOWED  | grep -v NOACCESS | grep -v grep | egrep  "[^\s]\.volume\_read\_test\.[^\s]" | awk '{ print $1}')
     if [ -z "$volumes" ]; then
 	echo "No suitable volumes found.  Skipping test and continuing." 1>&2
     else
 	#Pick a random volume.
 	volume=$(pick_random_volumes 1 $volumes)
+        echo "picked volume $volume"
 
 	outname=/dev/null
 


### PR DESCRIPTION
I played around with all the volumes marked NOACCESS that vol_read_test can randomly pick from.  I determined that only VR6994M8 and VR7017M8 actually fail the vol_read_test, so I left them as is and removed NOACCESS tags from the other ones.  I then modified the vol_read_test to not include NOACCESS tapes in its random selection.  
As modified in this PR, with the existing volume status, the test should pass reliably